### PR TITLE
When rebuilding, don't purge the entire state directory

### DIFF
--- a/cmd/solo/subcommand/destroy.go
+++ b/cmd/solo/subcommand/destroy.go
@@ -39,7 +39,7 @@ func NewDestroySubCommand(soloCtx *context.SoloContext) *cobra.Command {
 				return err
 			}
 
-			return projectControl.Destroy()
+			return projectControl.Destroy(true)
 		},
 	}
 

--- a/cmd/solo/subcommand/rebuild.go
+++ b/cmd/solo/subcommand/rebuild.go
@@ -39,7 +39,7 @@ func NewRebuildCommand(soloCtx *context.SoloContext) *cobra.Command {
 				return err
 			}
 
-			if err := projectControl.Destroy(); err != nil {
+			if err := projectControl.Destroy(false); err != nil {
 				return err
 			}
 

--- a/internal/pkg/solo/project/project.go
+++ b/internal/pkg/solo/project/project.go
@@ -72,8 +72,12 @@ func (t *Project) GetAllServicesStateDirectory() string {
 	return t.projectStateDirectory + "/services_all"
 }
 
+func (t *Project) GetServiceStateDirectoryRoot() string {
+	return t.projectStateDirectory + "/services"
+}
+
 func (t *Project) GetServiceStateDirectory(serviceName string) string {
-	return t.projectStateDirectory + "/services/" + serviceName
+	return t.GetServiceStateDirectoryRoot() + "/" + serviceName
 }
 
 func (t *Project) GetStateDirectoryRoot() string {

--- a/internal/pkg/solo/project_control.go
+++ b/internal/pkg/solo/project_control.go
@@ -114,7 +114,7 @@ func (t *ProjectControl) Stop() error {
 	return nil
 }
 
-func (t *ProjectControl) Destroy() error {
+func (t *ProjectControl) Destroy(purgeStateDirectory bool) error {
 	if err := t.composeFileExists(); err != nil {
 		return err
 	}
@@ -125,8 +125,23 @@ func (t *ProjectControl) Destroy() error {
 		return fmt.Errorf("error running compose: %v", err)
 	}
 
-	if err := os.RemoveAll(t.soloCtx.Project.GetStateDirectoryRoot()); err != nil {
-		return fmt.Errorf("failed to remove compose file: %v", err)
+	var purgeDirectoryList []string
+
+	if purgeStateDirectory {
+		// Purge the entire state directory
+		purgeDirectoryList = []string{t.soloCtx.Project.GetStateDirectoryRoot()}
+	} else {
+		// Purge only certain sub folders
+		purgeDirectoryList = []string{
+			t.soloCtx.Project.GetAllServicesStateDirectory(),
+			t.soloCtx.Project.GetServiceStateDirectoryRoot(),
+		}
+	}
+
+	for _, purgeDirectory := range purgeDirectoryList {
+		if err := os.RemoveAll(purgeDirectory); err != nil {
+			return fmt.Errorf("failed to remove state directory %s: %v", purgeDirectory, err)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
When rebuilding, don't purge the entire state directory. Instead, only purge the services and services_all sub directories.

When destroying, keep purging the entire state directory.