### PR TITLE
Expand linter rules to include gochecknoglobals and gochecknoinits

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,3 +6,5 @@ linters:
     - ineffassign
     - staticcheck
     - unused
+    - gochecknoglobals
+    - gochecknoinits


### PR DESCRIPTION
Expand linter rules to include gochecknoglobals and gochecknoinits