### PR TITLE
Integrate workflow tracking of services with start command

### DIFF
--- a/cmd/solo-entrypoint/main.go
+++ b/cmd/solo-entrypoint/main.go
@@ -18,9 +18,9 @@ func main() {
 
 	if true { // todo: detect build completed
 		workflowRunner.Execute(commonworkflow.Build)
-	} else {
-		workflowRunner.Execute(commonworkflow.PreStart)
 	}
+
+	workflowRunner.Execute(commonworkflow.PreStart)
 
 	err = forkAndExecute(os.Args[1:])
 	panic(err)

--- a/internal/pkg/common/wms/workflow_name.go
+++ b/internal/pkg/common/wms/workflow_name.go
@@ -1,6 +1,31 @@
 package wms
 
+import (
+	"fmt"
+)
+
 type Name int
+
+func FromString(name string) (Name, error) {
+	switch name {
+	case "build":
+		return Build, nil
+	case "pre_start":
+		return PreStart, nil
+	case "post_start":
+		return PostStart, nil
+	case "pre_stop":
+		return PreStop, nil
+	case "post_stop":
+		return PostStop, nil
+	case "pre_destroy":
+		return PreDestroy, nil
+	case "post_destroy":
+		return PostDestroy, nil
+	default:
+		return Unknown, fmt.Errorf("unknown workflow name: %s", name)
+	}
+}
 
 func (c Name) String() string {
 	switch c {
@@ -12,14 +37,24 @@ func (c Name) String() string {
 		return "post_start"
 	case PreStop:
 		return "pre_stop"
+	case PostStop:
+		return "post_stop"
+	case PreDestroy:
+		return "pre_destroy"
+	case PostDestroy:
+		return "post_destroy"
 	default:
 		return "unknown"
 	}
 }
 
 const (
-	Build Name = iota
+	Unknown Name = iota
+	Build
 	PreStart
 	PostStart
 	PreStop
+	PostStop
+	PreDestroy
+	PostDestroy
 )

--- a/internal/pkg/solo/events/manager.go
+++ b/internal/pkg/solo/events/manager.go
@@ -4,6 +4,7 @@ import "sync"
 
 type Manager interface {
 	Subscribe(eventSubscriber Subscriber)
+	Unsubscribe(eventSubscriber Subscriber)
 	Publish(data Event)
 }
 
@@ -33,6 +34,22 @@ func NewDefaultEventManager() Manager {
 
 func (t *DefaultManager) Subscribe(eventSubscriber Subscriber) {
 	t.subscribers = append(t.subscribers, eventSubscriber)
+}
+
+func (t *DefaultManager) Unsubscribe(eventSubscriber Subscriber) {
+	for index, targetSubscriber := range t.subscribers {
+		if targetSubscriber == eventSubscriber {
+			subscriberCount := len(t.subscribers)
+			if subscriberCount > 1 {
+				t.subscribers[index] = t.subscribers[subscriberCount-1]
+				t.subscribers = t.subscribers[:subscriberCount-1]
+			} else {
+				t.subscribers = []Subscriber{}
+			}
+
+			return
+		}
+	}
 }
 
 func (t *DefaultManager) Publish(event Event) {

--- a/internal/pkg/solo/grpc/service_definitions/workflow.go
+++ b/internal/pkg/solo/grpc/service_definitions/workflow.go
@@ -155,7 +155,6 @@ func (t WorkflowServerImpl) workflowStream(
 		},
 	})
 
-	t.soloCtx.Logger.Error("Workflow finished")
 	return server.Send(&services.WorkflowStreamResponse{
 		Action: services.WorkflowAction_COMPLETE_ACTION,
 	})

--- a/internal/pkg/solo/logs/log_writer_event_subscriber.go
+++ b/internal/pkg/solo/logs/log_writer_event_subscriber.go
@@ -17,8 +17,6 @@ func NewLogWriterEventSubscriber(soloCtx *context.SoloContext) events.Subscriber
 }
 
 func (t *LogWriterEventSubscriber) Publish(event events.Event) {
-	t.soloCtx.Logger.Info("LogWriterEventSubscriber:Publish")
-
 	switch event.(type) {
 	case wms.WorkflowStepOutputEvent:
 		// todo: implement write of command output and exit code to disk

--- a/internal/pkg/solo/project_control.go
+++ b/internal/pkg/solo/project_control.go
@@ -3,8 +3,10 @@ package solo
 import (
 	"errors"
 	"fmt"
+	workflowcommon "github.com/spaulg/solo/internal/pkg/common/wms"
 	"github.com/spaulg/solo/internal/pkg/solo/container"
 	"github.com/spaulg/solo/internal/pkg/solo/context"
+	"github.com/spaulg/solo/internal/pkg/solo/events"
 	"github.com/spaulg/solo/internal/pkg/solo/grpc"
 	"os"
 	"path"
@@ -13,6 +15,7 @@ import (
 
 type ProjectControl struct {
 	soloCtx           *context.SoloContext
+	workflowManager   events.Manager
 	composeFile       string
 	orchestrator      container.Orchestrator
 	grpcServerFactory grpc.ServerFactory
@@ -20,11 +23,13 @@ type ProjectControl struct {
 
 func NewProjectControl(
 	soloCtx *context.SoloContext,
+	workflowManager events.Manager,
 	orchestrator container.Orchestrator,
 	grpcServerFactory grpc.ServerFactory,
 ) *ProjectControl {
 	return &ProjectControl{
 		soloCtx:           soloCtx,
+		workflowManager:   workflowManager,
 		composeFile:       soloCtx.Project.ResolveStateDirectory("docker-compose.yml"),
 		orchestrator:      orchestrator,
 		grpcServerFactory: grpcServerFactory,
@@ -49,6 +54,22 @@ func (t *ProjectControl) Start() error {
 
 	defer grpcServer.Stop()
 
+	// Build workflow service map
+	workflowMap, err := t.buildWorkflowServiceMap([]workflowcommon.Name{
+		workflowcommon.Build,
+		workflowcommon.PreStart,
+		workflowcommon.PostStart,
+	})
+
+	if err != nil {
+		return err
+	}
+
+	// Register workflow guard
+	guard := NewProjectWorkflowGuard(t.soloCtx, workflowMap)
+	t.workflowManager.Subscribe(guard)
+	defer t.workflowManager.Unsubscribe(guard)
+
 	// Write compose file
 	composeYml, _ := t.orchestrator.ExportComposeConfiguration(t.soloCtx.Config, t.soloCtx.Project)
 	if err := t.exportComposeFile(composeYml); err != nil {
@@ -60,7 +81,12 @@ func (t *ProjectControl) Start() error {
 		return fmt.Errorf("error running composeCmd: %v", err)
 	}
 
-	if err := t.waitForWorkflowCompletion(60 * time.Second); err != nil {
+	// todo: only wait for Build if not previously started
+	if err := guard.WaitForCompletion(workflowcommon.Build, 60*time.Second); err != nil {
+		return err
+	}
+
+	if err := guard.WaitForCompletion(workflowcommon.PreStart, 60*time.Second); err != nil {
 		return err
 	}
 
@@ -152,33 +178,13 @@ func (t *ProjectControl) composeFileExists() error {
 	return nil
 }
 
-func (t *ProjectControl) waitForWorkflowCompletion(duration time.Duration) error {
-	timer := time.NewTimer(duration)
-	startTime := time.Now()
+func (t *ProjectControl) buildWorkflowServiceMap(workflowNames []workflowcommon.Name) (WorkflowServiceMap, error) {
+	serviceNames := t.soloCtx.Project.ServiceNames()
+	workflowMap := make(WorkflowServiceMap)
 
-	interrupt := make(chan struct{})
-
-	// Go routine to report timer status
-	go func() {
-		for {
-			time.Sleep(1 * time.Second)
-			remaining := duration - time.Since(startTime)
-			if remaining <= 0 {
-				return
-			}
-
-			t.soloCtx.Logger.Info(fmt.Sprintf("Time remaining: %v\n", remaining))
-		}
-	}()
-
-	// Wait for confirmation all containers have provisioned
-	// or expiry of the timer
-	select {
-	case <-timer.C:
-		t.soloCtx.Logger.Info("Timer expired")
-		return errors.New("provisioning timer expired")
-	case <-interrupt:
-		t.soloCtx.Logger.Info("All containers reported finished")
-		return nil
+	for _, workflowName := range workflowNames {
+		workflowMap[workflowName] = serviceNames
 	}
+
+	return workflowMap, nil
 }

--- a/internal/pkg/solo/project_control_factory.go
+++ b/internal/pkg/solo/project_control_factory.go
@@ -32,7 +32,7 @@ func ProjectControlFactory(soloCtx *context.SoloContext) (*ProjectControl, error
 	grpcServerFactory := grpc.NewMutualTLSServerFactory(certificateAuthority, workflowService)
 
 	// Project control
-	projectControl := NewProjectControl(soloCtx, containerOrchestrator, grpcServerFactory)
+	projectControl := NewProjectControl(soloCtx, eventManager, containerOrchestrator, grpcServerFactory)
 
 	return projectControl, nil
 }

--- a/internal/pkg/solo/project_workflow_guard.go
+++ b/internal/pkg/solo/project_workflow_guard.go
@@ -1,0 +1,97 @@
+package solo
+
+import (
+	"errors"
+	"fmt"
+	workflowcommon "github.com/spaulg/solo/internal/pkg/common/wms"
+	"github.com/spaulg/solo/internal/pkg/solo/context"
+	"github.com/spaulg/solo/internal/pkg/solo/events"
+	"github.com/spaulg/solo/internal/pkg/solo/wms"
+	"math"
+	"time"
+)
+
+type WorkflowServiceMap map[workflowcommon.Name][]string
+type WorkflowChannelMap map[workflowcommon.Name]chan interface{}
+
+type ProjectWorkflowGuard struct {
+	soloCtx          *context.SoloContext
+	workflowServices WorkflowServiceMap
+	workflowStatus   WorkflowServiceMap
+	workflowComplete WorkflowChannelMap
+}
+
+func NewProjectWorkflowGuard(soloCtx *context.SoloContext, workflowServices WorkflowServiceMap) *ProjectWorkflowGuard {
+	channels := make(WorkflowChannelMap)
+	for workflow := range workflowServices {
+		channels[workflow] = make(chan interface{})
+	}
+
+	return &ProjectWorkflowGuard{
+		soloCtx:          soloCtx,
+		workflowServices: workflowServices,
+		workflowStatus:   make(WorkflowServiceMap),
+		workflowComplete: channels,
+	}
+}
+
+func (t *ProjectWorkflowGuard) Publish(event events.Event) {
+	var workflowName workflowcommon.Name
+
+	switch e := event.(type) {
+	case *wms.WorkflowCompleteEvent:
+		workflowName = e.WorkflowName
+		t.workflowStatus[workflowName] = append(t.workflowStatus[workflowName], e.ServiceName)
+		t.soloCtx.Logger.Debug(fmt.Sprintf("Received event %s for service %s", workflowName, e.ServiceName))
+	default:
+		return
+	}
+
+	if len(t.workflowServices[workflowName]) == len(t.workflowStatus[workflowName]) {
+		t.soloCtx.Logger.Debug(fmt.Sprintf("All services completed workflow %s. Closing channel", workflowName))
+		close(t.workflowComplete[workflowName])
+	}
+}
+
+func (t *ProjectWorkflowGuard) WaitForCompletion(
+	workflowName workflowcommon.Name,
+	duration time.Duration,
+) error {
+	timer := time.NewTimer(duration)
+	startTime := time.Now()
+	stopped := false
+
+	t.soloCtx.Logger.Info(fmt.Sprintf("Waiting for all services to complete %s workflow, time remaining: %v", workflowName, duration.Seconds()))
+
+	// Report timer status through logs
+	go func() {
+		for {
+			time.Sleep(1 * time.Second)
+			remainingDuration := duration - time.Since(startTime)
+			remaining := remainingDuration.Seconds()
+
+			if stopped || remaining < 0 {
+				return
+			}
+
+			remainingRounded := int(math.Floor(remaining))
+			if (remainingRounded % 10) == 0 {
+				t.soloCtx.Logger.Info(fmt.Sprintf("Waiting for all services to complete %s workflow, time remaining: %v", workflowName, remainingRounded))
+			}
+		}
+	}()
+
+	// Wait for confirmation all containers have provisioned
+	// or expiry of the timer
+	select {
+	case <-timer.C:
+		t.soloCtx.Logger.Error(fmt.Sprintf("One or more services failed to complete workflow %s before timeout", workflowName))
+		return errors.New("provisioning timer expired")
+
+	case <-t.workflowComplete[workflowName]:
+		t.soloCtx.Logger.Info(fmt.Sprintf("All services completed workflow %s before timeout", workflowName))
+		timer.Stop()
+		stopped = true
+		return nil
+	}
+}


### PR DESCRIPTION
Integrate workflow tracking of services with start command. If all services checkin successfully, regard the execution as complete.