### PR TITLE
Group subcommands by lifeycle, tooling, config and other

### DIFF
--- a/cmd/solo/subcommand/clean.go
+++ b/cmd/solo/subcommand/clean.go
@@ -10,9 +10,10 @@ import (
 
 func NewCleanSubCommand(soloCtx *context.SoloContext) *cobra.Command {
 	return &cobra.Command{
-		Use:   "clean",
-		Short: "Clean the app",
-		Long:  "Clean the app",
+		Use:     "clean",
+		GroupID: "lifecycle",
+		Short:   "Clean the app",
+		Long:    "Clean the app",
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return soloCtx.TryLock()
 		},

--- a/cmd/solo/subcommand/destroy.go
+++ b/cmd/solo/subcommand/destroy.go
@@ -13,9 +13,10 @@ func NewDestroySubCommand(soloCtx *context.SoloContext) *cobra.Command {
 	var destroyCmdForce bool
 
 	destroyCmd := &cobra.Command{
-		Use:   "destroy",
-		Short: "Destroys your app",
-		Long:  "Destroys your app",
+		Use:     "destroy",
+		GroupID: "lifecycle",
+		Short:   "Destroys your app",
+		Long:    "Destroys your app",
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if err := soloCtx.TryLock(); err != nil {
 				return err

--- a/cmd/solo/subcommand/dumpComposeConfig.go
+++ b/cmd/solo/subcommand/dumpComposeConfig.go
@@ -9,9 +9,10 @@ import (
 
 func NewDumpComposeConfigCommand(soloCtx *context.SoloContext) *cobra.Command {
 	return &cobra.Command{
-		Use:   "dump-compose-config",
-		Short: "Dumps the compose config to stdout",
-		Long:  "Dumps the compose config to stdout",
+		Use:     "dump-compose-config",
+		GroupID: "config",
+		Short:   "Dumps the compose config to stdout",
+		Long:    "Dumps the compose config to stdout",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			composeYml, err := container.OrchestratorFactory(soloCtx).
 				ExportComposeConfiguration(soloCtx.Config, soloCtx.Project)

--- a/cmd/solo/subcommand/dumpConfig.go
+++ b/cmd/solo/subcommand/dumpConfig.go
@@ -9,9 +9,10 @@ import (
 
 func NewDumpConfigCommand(soloCtx *context.SoloContext) *cobra.Command {
 	return &cobra.Command{
-		Use:   "dump-config",
-		Short: "Dumps the solo config to stdout",
-		Long:  "Dumps the solo config to stdout",
+		Use:     "dump-config",
+		GroupID: "config",
+		Short:   "Dumps the solo config to stdout",
+		Long:    "Dumps the solo config to stdout",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			configYaml, err := yaml.Marshal(soloCtx.Config)
 			if err != nil {

--- a/cmd/solo/subcommand/logs.go
+++ b/cmd/solo/subcommand/logs.go
@@ -8,9 +8,10 @@ import (
 
 func NewLogsCommand(_ *context.SoloContext) *cobra.Command {
 	return &cobra.Command{
-		Use:   "logs",
-		Short: "Displays logs for your app",
-		Long:  "Displays logs for your app",
+		Use:     "logs",
+		GroupID: "tooling",
+		Short:   "Displays logs for your app",
+		Long:    "Displays logs for your app",
 		Run: func(cmd *cobra.Command, args []string) {
 			fmt.Println("logs called")
 		},

--- a/cmd/solo/subcommand/rebuild.go
+++ b/cmd/solo/subcommand/rebuild.go
@@ -13,9 +13,10 @@ func NewRebuildCommand(soloCtx *context.SoloContext) *cobra.Command {
 	var rebuildCmdForce bool
 
 	rebuildCmd := &cobra.Command{
-		Use:   "rebuild",
-		Short: "Rebuilds your app from scratch, preserving data",
-		Long:  "Rebuilds your app from scratch, preserving data",
+		Use:     "rebuild",
+		GroupID: "lifecycle",
+		Short:   "Rebuilds your app from scratch, preserving data",
+		Long:    "Rebuilds your app from scratch, preserving data",
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if err := soloCtx.TryLock(); err != nil {
 				return err

--- a/cmd/solo/subcommand/restart.go
+++ b/cmd/solo/subcommand/restart.go
@@ -8,9 +8,10 @@ import (
 
 func NewRestartCommand(soloCtx *context.SoloContext) *cobra.Command {
 	return &cobra.Command{
-		Use:   "restart",
-		Short: "Restarts your app",
-		Long:  "Restarts your app",
+		Use:     "restart",
+		GroupID: "lifecycle",
+		Short:   "Restarts your app",
+		Long:    "Restarts your app",
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return soloCtx.TryLock()
 		},

--- a/cmd/solo/subcommand/root.go
+++ b/cmd/solo/subcommand/root.go
@@ -45,19 +45,32 @@ func NewRootCommand(soloCtx *context.SoloContext) *cobra.Command {
 }
 
 func Execute() {
+	cobra.EnableCommandSorting = false
+
 	soloCtx := loadConfigAndProjectContext()
 
 	rootCmd := NewRootCommand(soloCtx)
-	rootCmd.AddCommand(NewCleanSubCommand(soloCtx))
-	rootCmd.AddCommand(NewDestroySubCommand(soloCtx))
-	rootCmd.AddCommand(NewDumpComposeConfigCommand(soloCtx))
-	rootCmd.AddCommand(NewDumpConfigCommand(soloCtx))
-	rootCmd.AddCommand(NewLogsCommand(soloCtx))
-	rootCmd.AddCommand(NewRebuildCommand(soloCtx))
-	rootCmd.AddCommand(NewRestartCommand(soloCtx))
-	rootCmd.AddCommand(NewSSHCommand(soloCtx))
+	rootCmd.AddGroup(&cobra.Group{ID: "lifecycle", Title: "Life Cycle Commands:"})
+	rootCmd.AddGroup(&cobra.Group{ID: "tooling", Title: "Tooling Commands:"})
+	rootCmd.AddGroup(&cobra.Group{ID: "config", Title: "Config Commands:"})
+
+	// Lifecycle
 	rootCmd.AddCommand(NewStartCommand(soloCtx))
 	rootCmd.AddCommand(NewStopCommand(soloCtx))
+	rootCmd.AddCommand(NewRestartCommand(soloCtx))
+	rootCmd.AddCommand(NewRebuildCommand(soloCtx))
+	rootCmd.AddCommand(NewDestroySubCommand(soloCtx))
+	rootCmd.AddCommand(NewCleanSubCommand(soloCtx))
+
+	// Tooling
+	rootCmd.AddCommand(NewSSHCommand(soloCtx))
+	rootCmd.AddCommand(NewLogsCommand(soloCtx))
+
+	// Config
+	rootCmd.AddCommand(NewDumpConfigCommand(soloCtx))
+	rootCmd.AddCommand(NewDumpComposeConfigCommand(soloCtx))
+
+	// Other
 	rootCmd.AddCommand(NewVersionCommand(soloCtx))
 
 	err := rootCmd.Execute()

--- a/cmd/solo/subcommand/ssh.go
+++ b/cmd/solo/subcommand/ssh.go
@@ -8,8 +8,9 @@ import (
 
 func NewSSHCommand(_ *context.SoloContext) *cobra.Command {
 	return &cobra.Command{
-		Use:   "ssh",
-		Short: "Drops into a shell on a service, runs commands",
+		Use:     "ssh",
+		GroupID: "tooling",
+		Short:   "Drops into a shell on a service, runs commands",
 		Long: `A longer description that spans multiple lines and likely contains examples
 and usage of using your command. For example:
 

--- a/cmd/solo/subcommand/start.go
+++ b/cmd/solo/subcommand/start.go
@@ -8,9 +8,10 @@ import (
 
 func NewStartCommand(soloCtx *context.SoloContext) *cobra.Command {
 	return &cobra.Command{
-		Use:   "start",
-		Short: "Starts your app",
-		Long:  "Starts your app",
+		Use:     "start",
+		GroupID: "lifecycle",
+		Short:   "Starts your app",
+		Long:    "Starts your app",
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return soloCtx.TryLock()
 		},

--- a/cmd/solo/subcommand/stop.go
+++ b/cmd/solo/subcommand/stop.go
@@ -8,9 +8,10 @@ import (
 
 func NewStopCommand(soloCtx *context.SoloContext) *cobra.Command {
 	return &cobra.Command{
-		Use:   "stop",
-		Short: "Stops your app",
-		Long:  "Stops your app",
+		Use:     "stop",
+		GroupID: "lifecycle",
+		Short:   "Stops your app",
+		Long:    "Stops your app",
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return soloCtx.TryLock()
 		},


### PR DESCRIPTION
Group subcommands by lifeycle, tooling, config and other and disable alphabetical ordering of the commands.