### PR TITLE
Use compose file from state directory if exists

### DIFF
--- a/cmd/solo/subcommand/root.go
+++ b/cmd/solo/subcommand/root.go
@@ -123,11 +123,17 @@ func buildLogLevel(soloCtx *context.SoloContext) slog.Level {
 }
 
 func loadConfigAndProjectContext() *context.SoloContext {
-	loadedConfig, configLoadErr := config.NewConfig()
-	loadedProject, projectLoadErr := project.FindProject("./")
+	var loadedProject *project.Project
+	var projectLoadErr error
 
-	if loadedProject != nil && configLoadErr == nil {
-		configLoadErr = loadedConfig.AddConfigPath(loadedProject.GetDirectory())
+	loadedConfig, configLoadErr := config.NewConfig()
+
+	if configLoadErr == nil {
+		loadedProject, projectLoadErr = project.FindProject("./", loadedConfig)
+
+		if projectLoadErr == nil {
+			configLoadErr = loadedConfig.AddConfigPath(loadedProject.GetDirectory())
+		}
 	}
 
 	return &context.SoloContext{

--- a/internal/pkg/solo/config/config.go
+++ b/internal/pkg/solo/config/config.go
@@ -14,29 +14,32 @@ type LoggingConfig struct {
 type Config struct {
 	reader *viper.Viper
 
-	Entrypoint     string
-	LocalDirectory string
-	Orchestrator   string
-	GrpcServerPort uint16
-	Logging        LoggingConfig
+	Entrypoint         string
+	StateDirectoryName string
+	ComposeFileName    string
+	Orchestrator       string
+	GrpcServerPort     uint16
+	Logging            LoggingConfig
 }
 
 const (
-	DefaultEntrypoint     = "/usr/local/bin/solo-entrypoint"
-	DefaultLocalDirectory = "./.solo"
-	DefaultOrchestrator   = "docker"
-	DefaultGrpcServerPort = 0
-	DefaultLoggingEnabled = false
-	DefaultLoggingLevel   = "warning"
-	DefaultLoggingHandler = "text"
+	DefaultEntrypoint         = "/usr/local/bin/solo-entrypoint"
+	DefaultStateDirectoryName = "./.solo"
+	DefaultOrchestrator       = "docker"
+	DefaultGrpcServerPort     = 0
+	DefaultLoggingEnabled     = false
+	DefaultLoggingLevel       = "warning"
+	DefaultLoggingHandler     = "text"
+	DefaultComposeFileName    = "docker-compose.yml"
 )
 
 func NewConfig() (*Config, error) {
 	config := Config{
-		Entrypoint:     DefaultEntrypoint,
-		LocalDirectory: DefaultLocalDirectory,
-		Orchestrator:   DefaultOrchestrator,
-		GrpcServerPort: DefaultGrpcServerPort,
+		Entrypoint:         DefaultEntrypoint,
+		StateDirectoryName: DefaultStateDirectoryName,
+		Orchestrator:       DefaultOrchestrator,
+		GrpcServerPort:     DefaultGrpcServerPort,
+		ComposeFileName:    DefaultComposeFileName,
 
 		Logging: LoggingConfig{
 			Enabled: DefaultLoggingEnabled,

--- a/internal/pkg/solo/config/config_test.go
+++ b/internal/pkg/solo/config/config_test.go
@@ -15,8 +15,8 @@ func TestConfigLoading(t *testing.T) {
 		t.Fatal("Entrypoint does not match default")
 	}
 
-	if config.LocalDirectory != DefaultLocalDirectory {
-		t.Fatal("LocalDirectory does not match default")
+	if config.StateDirectoryName != DefaultStateDirectoryName {
+		t.Fatal("StateDirectoryName does not match default")
 	}
 
 	if err := config.AddConfigPath("test/data/config"); err != nil {
@@ -27,8 +27,8 @@ func TestConfigLoading(t *testing.T) {
 		t.Fatalf("Entrypoint %s does not match overridden config %s", config.Entrypoint, "/opt/bin/solo-custom-entrypoint.sh")
 	}
 
-	if config.LocalDirectory != "/opt/solo" {
-		t.Fatalf("LocalDirectory %s does not match overridden config %s", config.LocalDirectory, "/opt/solo")
+	if config.StateDirectoryName != "/opt/solo" {
+		t.Fatalf("StateDirectoryName %s does not match overridden config %s", config.StateDirectoryName, "/opt/solo")
 	}
 }
 
@@ -42,8 +42,8 @@ func TestConfigPathNotFound(t *testing.T) {
 		t.Fatal("Entrypoint does not match default")
 	}
 
-	if config.LocalDirectory != DefaultLocalDirectory {
-		t.Fatal("LocalDirectory does not match default")
+	if config.StateDirectoryName != DefaultStateDirectoryName {
+		t.Fatal("StateDirectoryName does not match default")
 	}
 
 	if err := config.AddConfigPath("test/data/config/notfound"); err != nil {
@@ -54,7 +54,7 @@ func TestConfigPathNotFound(t *testing.T) {
 		t.Fatal("Entrypoint does not match default")
 	}
 
-	if config.LocalDirectory != DefaultLocalDirectory {
-		t.Fatal("LocalDirectory does not match default")
+	if config.StateDirectoryName != DefaultStateDirectoryName {
+		t.Fatal("StateDirectoryName does not match default")
 	}
 }

--- a/internal/pkg/solo/project/finder.go
+++ b/internal/pkg/solo/project/finder.go
@@ -2,6 +2,7 @@ package project
 
 import (
 	"errors"
+	"github.com/spaulg/solo/internal/pkg/solo/config"
 	"os"
 	"path/filepath"
 )
@@ -11,7 +12,7 @@ const DefaultProjectFileName = "solo.yml"
 // FindProject Find the project file by navigating up the
 // filesystem tree until the project file is found, or
 // return error if no project file is found
-func FindProject(startPath string) (*Project, error) {
+func FindProject(startPath string, config *config.Config) (*Project, error) {
 	var projectFilePath string
 
 	path, err := filepath.Abs(startPath)
@@ -37,7 +38,7 @@ func FindProject(startPath string) (*Project, error) {
 				return nil, err
 			}
 		} else if fileInfo != nil {
-			return NewProject(projectFilePath)
+			return NewProject(projectFilePath, config)
 		}
 	}
 

--- a/internal/pkg/solo/project/project.go
+++ b/internal/pkg/solo/project/project.go
@@ -8,7 +8,9 @@ import (
 	"github.com/compose-spec/compose-go/v2/types"
 	"github.com/sirupsen/logrus"
 	workflowcommon "github.com/spaulg/solo/internal/pkg/common/wms"
+	"github.com/spaulg/solo/internal/pkg/solo/config"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 	"time"
@@ -19,14 +21,15 @@ type compose = types.Project
 type Project struct {
 	*compose
 
-	projectStateDirectory string
-	directory             string
-	filePath              string
+	projectStateDirectory    string
+	generatedComposeFilepath string
+	directory                string
+	filePath                 string
 }
 
-func NewProject(projectFilePath string) (*Project, error) {
+func NewProject(projectFilePath string, config *config.Config) (*Project, error) {
 	projectOptions, err := cli.NewProjectOptions(nil,
-		WithComposeFiles(projectFilePath),
+		WithComposeFiles(projectFilePath, config),
 		cli.WithLoadOptions(func(option *loader.Options) {
 			option.ResolvePaths = false // Keep paths relative in case the user moves their project folder
 		}),
@@ -44,10 +47,11 @@ func NewProject(projectFilePath string) (*Project, error) {
 
 	projectDirectory := filepath.Dir(projectFilePath)
 	project := &Project{
-		projectStateDirectory: projectDirectory + "/.solo",
-		directory:             projectDirectory,
-		filePath:              projectFilePath,
-		compose:               compose,
+		projectStateDirectory:    path.Join(projectDirectory, config.StateDirectoryName),
+		generatedComposeFilepath: config.ComposeFileName,
+		directory:                projectDirectory,
+		filePath:                 projectFilePath,
+		compose:                  compose,
 	}
 
 	// Set default values in extensions
@@ -57,19 +61,19 @@ func NewProject(projectFilePath string) (*Project, error) {
 }
 
 func (t *Project) ResolveStateDirectory(relativePath string) string {
-	return t.projectStateDirectory + "/" + relativePath
+	return path.Join(t.projectStateDirectory, relativePath)
 }
 
 func (t *Project) GetAllServicesStateDirectory() string {
-	return t.projectStateDirectory + "/services_all"
+	return path.Join(t.projectStateDirectory, "services_all")
 }
 
 func (t *Project) GetServiceStateDirectoryRoot() string {
-	return t.projectStateDirectory + "/services"
+	return path.Join(t.projectStateDirectory, "services")
 }
 
 func (t *Project) GetServiceStateDirectory(serviceName string) string {
-	return t.GetServiceStateDirectoryRoot() + "/" + serviceName
+	return path.Join(t.GetServiceStateDirectoryRoot(), serviceName)
 }
 
 func (t *Project) GetStateDirectoryRoot() string {
@@ -85,17 +89,21 @@ func (t *Project) GetFilePath() string {
 }
 
 func (t *Project) GetServiceWorkflow(serviceName string, eventName string) ServiceWorkflowConfig {
-	config := t.Services[serviceName].Extensions[ServiceWorkflowExtensionName].(ServiceWorkflows)
-	return config[eventName]
+	serviceWorkflows := t.Services[serviceName].Extensions[ServiceWorkflowExtensionName].(ServiceWorkflows)
+	return serviceWorkflows[eventName]
+}
+
+func (t *Project) GetGeneratedComposeFilePath() string {
+	return path.Join(t.projectStateDirectory, t.generatedComposeFilepath)
 }
 
 func (t *Project) GetMaxWorkflowTimeout(eventName string) time.Duration {
 	maxTimeout := types.Duration(0)
 
 	for _, serviceConfig := range t.Services {
-		config := serviceConfig.Extensions[ServiceWorkflowExtensionName].(ServiceWorkflows)
+		serviceWorkflows := serviceConfig.Extensions[ServiceWorkflowExtensionName].(ServiceWorkflows)
 
-		if v, ok := config[eventName]; ok && *v.Timeout > maxTimeout {
+		if v, ok := serviceWorkflows[eventName]; ok && *v.Timeout > maxTimeout {
 			maxTimeout = *v.Timeout
 		}
 	}
@@ -103,10 +111,20 @@ func (t *Project) GetMaxWorkflowTimeout(eventName string) time.Duration {
 	return time.Duration(maxTimeout)
 }
 
-func WithComposeFiles(projectFilePath string) func(o *cli.ProjectOptions) error {
+func WithComposeFiles(projectFilePath string, config *config.Config) func(o *cli.ProjectOptions) error {
 	return func(o *cli.ProjectOptions) error {
 		projectDirectory := filepath.Dir(projectFilePath)
-		candidates := findFiles(cli.DefaultFileNames, projectDirectory)
+
+		// Look for generated compose yaml file in the state directory
+		// If found, use this, if not, find normal compose and override
+		candidates := findFiles([]string{"docker-compose.yml"}, projectDirectory+"/"+config.StateDirectoryName)
+		if len(candidates) == 1 {
+			o.ConfigPaths = append(o.ConfigPaths, candidates[0])
+			return nil
+		}
+
+		// Look for compose files in the project directory
+		candidates = findFiles(cli.DefaultFileNames, projectDirectory)
 
 		if len(candidates) > 0 {
 			winner := candidates[0]

--- a/internal/pkg/solo/project_control.go
+++ b/internal/pkg/solo/project_control.go
@@ -15,7 +15,6 @@ import (
 type ProjectControl struct {
 	soloCtx           *context.SoloContext
 	workflowManager   events.Manager
-	composeFile       string
 	orchestrator      container.Orchestrator
 	grpcServerFactory grpc.ServerFactory
 }
@@ -29,7 +28,6 @@ func NewProjectControl(
 	return &ProjectControl{
 		soloCtx:           soloCtx,
 		workflowManager:   workflowManager,
-		composeFile:       soloCtx.Project.ResolveStateDirectory("docker-compose.yml"),
 		orchestrator:      orchestrator,
 		grpcServerFactory: grpcServerFactory,
 	}
@@ -76,7 +74,7 @@ func (t *ProjectControl) Start() error {
 	}
 
 	// Start compose services
-	if err := t.orchestrator.Up(t.soloCtx.Project.GetDirectory(), t.composeFile); err != nil {
+	if err := t.orchestrator.Up(t.soloCtx.Project.GetDirectory(), t.soloCtx.Project.GetGeneratedComposeFilePath()); err != nil {
 		return fmt.Errorf("error running composeCmd: %v", err)
 	}
 
@@ -102,7 +100,7 @@ func (t *ProjectControl) Stop() error {
 
 	// todo: Exec pre stop commands
 
-	if err := t.orchestrator.Down(t.soloCtx.Project.GetDirectory(), t.composeFile); err != nil {
+	if err := t.orchestrator.Down(t.soloCtx.Project.GetDirectory(), t.soloCtx.Project.GetGeneratedComposeFilePath()); err != nil {
 		return fmt.Errorf("error running compose: %v", err)
 	}
 
@@ -116,7 +114,7 @@ func (t *ProjectControl) Destroy() error {
 
 	// todo: Exec pre stop commands
 
-	if err := t.orchestrator.Destroy(t.soloCtx.Project.GetDirectory(), t.composeFile); err != nil {
+	if err := t.orchestrator.Destroy(t.soloCtx.Project.GetDirectory(), t.soloCtx.Project.GetGeneratedComposeFilePath()); err != nil {
 		return fmt.Errorf("error running compose: %v", err)
 	}
 
@@ -132,6 +130,7 @@ func (t *ProjectControl) Clean(purgeStateDirectory bool) error {
 	} else {
 		// Purge only certain sub folders
 		purgeDirectoryList = []string{
+			t.soloCtx.Project.GetGeneratedComposeFilePath(),
 			t.soloCtx.Project.GetAllServicesStateDirectory(),
 			t.soloCtx.Project.GetServiceStateDirectoryRoot(),
 		}
@@ -147,7 +146,7 @@ func (t *ProjectControl) Clean(purgeStateDirectory bool) error {
 }
 
 func (t *ProjectControl) exportComposeFile(composeYml []byte) error {
-	composeDirectory := path.Dir(t.composeFile)
+	composeDirectory := path.Dir(t.soloCtx.Project.GetGeneratedComposeFilePath())
 	if _, err := os.Stat(composeDirectory); err != nil {
 		if !errors.Is(err, os.ErrNotExist) {
 			return fmt.Errorf("failed to check .solo directory existence: %v", err)
@@ -158,7 +157,7 @@ func (t *ProjectControl) exportComposeFile(composeYml []byte) error {
 		}
 	}
 
-	if err := os.WriteFile(t.composeFile, composeYml, 0640); err != nil {
+	if err := os.WriteFile(t.soloCtx.Project.GetGeneratedComposeFilePath(), composeYml, 0640); err != nil {
 		return fmt.Errorf("failed to write compose file: %v", err)
 	}
 
@@ -166,7 +165,7 @@ func (t *ProjectControl) exportComposeFile(composeYml []byte) error {
 }
 
 func (t *ProjectControl) composeFileExists() error {
-	if _, err := os.Stat(t.composeFile); err != nil {
+	if _, err := os.Stat(t.soloCtx.Project.GetGeneratedComposeFilePath()); err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return fmt.Errorf("compose file not found")
 		} else {


### PR DESCRIPTION
Use the compose file from the state directory, if it exists. Otherwise use the project files as normal. This ensure we do not use an inconsistent project files not sync'ed with the generated compose file