### PR TITLE
Rename the build workflow event to first_pre_start instead

### DIFF
--- a/cmd/solo-entrypoint/subcommand/entrypoint.go
+++ b/cmd/solo-entrypoint/subcommand/entrypoint.go
@@ -27,7 +27,7 @@ func NewEntrypointCommand(entrypointCtx *context.EntrypointContext) *cobra.Comma
 			defer workflowRunner.Close()
 
 			if !isServiceBuilt() {
-				workflowRunner.Execute(commonworkflow.Build)
+				workflowRunner.Execute(commonworkflow.FirstPreStart)
 			}
 
 			workflowRunner.Execute(commonworkflow.PreStart)

--- a/internal/pkg/common/grpc/services/workflow.proto
+++ b/internal/pkg/common/grpc/services/workflow.proto
@@ -37,7 +37,7 @@ message WorkflowRunResult {
 }
 
 service Workflow {
-  rpc BuildWorkflowStream(stream WorkflowStreamRequest) returns (stream WorkflowStreamResponse);
+  rpc FirstPreStartWorkflowStream(stream WorkflowStreamRequest) returns (stream WorkflowStreamResponse);
   rpc PreStartWorkflowStream(stream WorkflowStreamRequest) returns (stream WorkflowStreamResponse);
   rpc PostStartWorkflowStream(stream WorkflowStreamRequest) returns (stream WorkflowStreamResponse);
   rpc PreStopWorkflowStream(stream WorkflowStreamRequest) returns (stream WorkflowStreamResponse);

--- a/internal/pkg/common/wms/workflow_name.go
+++ b/internal/pkg/common/wms/workflow_name.go
@@ -8,7 +8,7 @@ type Name int
 
 // nolint:gochecknoglobals
 var WorkflowNames = []Name{
-	Build,
+	FirstPreStart,
 	PreStart,
 	PostStart,
 	PreStop,
@@ -19,8 +19,8 @@ var WorkflowNames = []Name{
 
 func FromString(name string) (Name, error) {
 	switch name {
-	case "build":
-		return Build, nil
+	case "first_pre_start":
+		return FirstPreStart, nil
 	case "pre_start":
 		return PreStart, nil
 	case "post_start":
@@ -40,8 +40,8 @@ func FromString(name string) (Name, error) {
 
 func (c Name) String() string {
 	switch c {
-	case Build:
-		return "build"
+	case FirstPreStart:
+		return "first_pre_start"
 	case PreStart:
 		return "pre_start"
 	case PostStart:
@@ -61,7 +61,7 @@ func (c Name) String() string {
 
 const (
 	Undefined Name = iota
-	Build
+	FirstPreStart
 	PreStart
 	PostStart
 	PreStop

--- a/internal/pkg/entrypoint/workflow/grpc_workflow_runner.go
+++ b/internal/pkg/entrypoint/workflow/grpc_workflow_runner.go
@@ -117,8 +117,8 @@ func (t *GrpcWorkflowRunner) Close() error {
 
 func (t *GrpcWorkflowRunner) buildStream(workflowName commonworkflow.Name) (WorkflowStream, error) {
 	switch workflowName {
-	case commonworkflow.Build:
-		return t.workflowClient.BuildWorkflowStream(context.Background())
+	case commonworkflow.FirstPreStart:
+		return t.workflowClient.FirstPreStartWorkflowStream(context.Background())
 	case commonworkflow.PreStart:
 		return t.workflowClient.PreStartWorkflowStream(context.Background())
 	case commonworkflow.PostStart:

--- a/internal/pkg/solo/grpc/service_definitions/workflow.go
+++ b/internal/pkg/solo/grpc/service_definitions/workflow.go
@@ -31,10 +31,10 @@ func NewWorkflowService(
 	}
 }
 
-func (t WorkflowServerImpl) BuildWorkflowStream(
+func (t WorkflowServerImpl) FirstPreStartWorkflowStream(
 	server grpc.BidiStreamingServer[services.WorkflowStreamRequest, services.WorkflowStreamResponse],
 ) error {
-	return t.workflowStream(commonworkflow.Build, server)
+	return t.workflowStream(commonworkflow.FirstPreStart, server)
 }
 
 func (t WorkflowServerImpl) PreStartWorkflowStream(

--- a/internal/pkg/solo/project_control.go
+++ b/internal/pkg/solo/project_control.go
@@ -55,7 +55,7 @@ func (t *ProjectControl) Start() error {
 
 	// Build workflow service map
 	workflowMap, err := t.buildWorkflowServiceMap([]workflowcommon.Name{
-		workflowcommon.Build,
+		workflowcommon.FirstPreStart,
 		workflowcommon.PreStart,
 		workflowcommon.PostStart,
 	})
@@ -82,7 +82,7 @@ func (t *ProjectControl) Start() error {
 		return fmt.Errorf("error running compose: %v", err)
 	}
 
-	if err := guard.WaitForCompletion(workflowcommon.Build); err != nil {
+	if err := guard.WaitForCompletion(workflowcommon.FirstPreStart); err != nil {
 		return err
 	}
 
@@ -279,7 +279,7 @@ func (t *ProjectControl) buildWorkflowServiceMap(workflowNames []workflowcommon.
 	workflowMap := make(WorkflowServiceMap)
 
 	for _, workflowName := range workflowNames {
-		if workflowName == workflowcommon.Build {
+		if workflowName == workflowcommon.FirstPreStart {
 			servicesToBuild := t.soloCtx.Project.ServicesPendingBuildWorkflow()
 
 			if len(servicesToBuild) > 0 {

--- a/internal/pkg/solo/subscribers/build_complete_event_subscriber.go
+++ b/internal/pkg/solo/subscribers/build_complete_event_subscriber.go
@@ -23,7 +23,7 @@ func NewBuildCompleteEventSubscriber(soloCtx *context.CliContext) events.Subscri
 func (t *BuildCompleteEventSubscriber) Publish(event events.Event) {
 	switch e := event.(type) {
 	case *wms.WorkflowCompleteEvent:
-		if e.WorkflowName == commonworkflow.Build && e.Successful {
+		if e.WorkflowName == commonworkflow.FirstPreStart && e.Successful {
 			t.soloCtx.Logger.Info(fmt.Sprintf("Writing build complete marker for %s", e.ServiceName))
 
 			markerFile := path.Join(t.soloCtx.Project.GetServiceMountDirectory(e.ServiceName), "build_complete")

--- a/solo.yml
+++ b/solo.yml
@@ -11,7 +11,7 @@ services:
       - "./go.sum:/solo/go.sum"
 
     x-workflows:
-      build:
+      first_pre_start:
         steps:
           - name: 'List files in root'
             command: '/bin/ls -lh'


### PR DESCRIPTION
Rename the build workflow event to first_pre_start instead to avoid confusion with the container image build phase of bringing up a docker compose app.