### PR TITLE
Switch lock file implementation to use flock to auto release the lock

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.23.4
 
 require (
 	github.com/compose-spec/compose-go/v2 v2.2.0
+	github.com/gofrs/flock v0.12.1
 	github.com/sirupsen/logrus v1.9.0
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/viper v1.19.0

--- a/go.sum
+++ b/go.sum
@@ -17,6 +17,8 @@ github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nos
 github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
 github.com/go-viper/mapstructure/v2 v2.0.0 h1:dhn8MZ1gZ0mzeodTG3jt5Vj/o87xZKuNAprG2mQfMfc=
 github.com/go-viper/mapstructure/v2 v2.0.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
+github.com/gofrs/flock v0.12.1 h1:MTLVXXHf8ekldpJk3AKicLij9MdwOWkZ+a/jHHZby9E=
+github.com/gofrs/flock v0.12.1/go.mod h1:9zxTsyu5xtJ9DK+1tFZyibEV7y3uwDxPPfbxeeHCoD0=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
@@ -102,8 +104,8 @@ google.golang.org/grpc v1.67.1/go.mod h1:1gLDyUQU7CTLJI90u3nXZ9ekeghjeM7pTDZlqFN
 google.golang.org/protobuf v1.34.2 h1:6xV6lTsCfpGD21XK49h7MhtcApnLqkfYgPcdHftf6hg=
 google.golang.org/protobuf v1.34.2/go.mod h1:qYOHts0dSfpeUzUFpOMr/WGzszTmLH+DiWniOlNbLDw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
-gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/ini.v1 v1.67.0 h1:Dgnx+6+nfE+IfzjUEISNeydPJh9AXNNsWbGP9KzCsOA=
 gopkg.in/ini.v1 v1.67.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/pkg/solo/context/cli_context.go
+++ b/internal/pkg/solo/context/cli_context.go
@@ -1,8 +1,8 @@
 package context
 
 import (
-	"errors"
 	"fmt"
+	"github.com/gofrs/flock"
 	"github.com/spaulg/solo/internal/pkg/solo/config"
 	"github.com/spaulg/solo/internal/pkg/solo/project"
 	"github.com/spf13/cobra"
@@ -10,7 +10,7 @@ import (
 	"os"
 )
 
-const lockFileName = "lock"
+const lockFileName = "locking_file"
 
 type CliContext struct {
 	Project        *project.Project
@@ -18,7 +18,7 @@ type CliContext struct {
 	ProjectLoadErr error
 	ConfigLoadErr  error
 	Logger         *slog.Logger
-	lockFile       *os.File
+	lockFile       *flock.Flock
 }
 
 func (t *CliContext) ProtectWithLock(impl func(*cobra.Command, []string) error) func(cmd *cobra.Command, args []string) error {
@@ -27,35 +27,31 @@ func (t *CliContext) ProtectWithLock(impl func(*cobra.Command, []string) error) 
 			return err
 		}
 
-		commandErr := impl(cmd, args)
-
-		if err := t.Unlock(); err != nil {
-			if !errors.Is(err, os.ErrNotExist) {
-				return fmt.Errorf("%v: %v", err, commandErr)
-			}
-		}
-
-		return commandErr
+		return impl(cmd, args)
 	}
 }
 
 func (t *CliContext) TryLock() error {
-	var err error
-	lockFile := t.Project.ResolveStateDirectory(lockFileName)
-	t.lockFile, err = os.OpenFile(lockFile, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0600)
-	if errors.Is(err, os.ErrExist) {
-		return errors.New("lock file exists")
+	// Create the lock file if it does not already exist
+	lockFileName := t.Project.ResolveStateDirectory(lockFileName)
+
+	lockFile, err := os.OpenFile(lockFileName, os.O_WRONLY|os.O_CREATE, 0600)
+	if err != nil {
+		return err
+	} else {
+		_ = lockFile.Close()
 	}
 
-	return err
-}
-
-func (t *CliContext) Unlock() error {
-	lockFile := t.lockFile.Name()
-
-	if err := t.lockFile.Close(); err != nil {
+	// Lock the locking file with an optimistic exclusive write lock
+	t.lockFile = flock.New(lockFileName)
+	locked, err := t.lockFile.TryLock()
+	if err != nil {
 		return err
 	}
 
-	return os.Remove(lockFile)
+	if !locked {
+		return fmt.Errorf("could not acquire lock")
+	}
+
+	return nil
 }


### PR DESCRIPTION
Switch lock file implementation to use flock to auto release the lock when the process exists. This avoids leaving lock files behind that must be manually removed.