### PR TITLE
Use the entrypoint binary from the state directory to fix compose

### DIFF
--- a/internal/pkg/solo/config/config.go
+++ b/internal/pkg/solo/config/config.go
@@ -6,37 +6,47 @@ import (
 )
 
 type LoggingConfig struct {
-	Enabled bool
-	Level   string
-	Handler string
+	Enabled bool   `mapstructure:"enabled"`
+	Level   string `mapstructure:"level"`
+	Handler string `mapstructure:"handler"`
+}
+
+type Entrypoint struct {
+	HostEntrypointPath      string `mapstructure:"host_entrypoint_path"`
+	ContainerEntrypointPath string `mapstructure:"container_entrypoint_path"`
 }
 
 type Config struct {
 	reader *viper.Viper
 
-	Entrypoint         string
-	StateDirectoryName string
-	Orchestrator       string
-	GrpcServerPort     uint16
-	Logging            LoggingConfig
+	Entrypoint         Entrypoint    `mapstructure:"entrypoint"`
+	Logging            LoggingConfig `mapstructure:"logging"`
+	StateDirectoryName string        `mapstructure:"state_directory_name"`
+	Orchestrator       string        `mapstructure:"orchestrator"`
+	GrpcServerPort     uint16        `mapstructure:"grpc_server_port"`
 }
 
 const (
-	DefaultEntrypoint         = "/usr/local/bin/solo-entrypoint"
-	DefaultStateDirectoryName = "./.solo"
-	DefaultOrchestrator       = "docker"
-	DefaultGrpcServerPort     = 0
-	DefaultLoggingEnabled     = true
-	DefaultLoggingLevel       = "warning"
-	DefaultLoggingHandler     = "text"
+	DefaultHostEntrypoint      = "/usr/local/bin/solo-entrypoint"
+	DefaultContainerEntrypoint = "/usr/local/sbin/solo"
+	DefaultStateDirectoryName  = "./.solo"
+	DefaultOrchestrator        = "docker"
+	DefaultGrpcServerPort      = 0
+	DefaultLoggingEnabled      = true
+	DefaultLoggingLevel        = "warning"
+	DefaultLoggingHandler      = "text"
 )
 
 func NewConfig() (*Config, error) {
 	config := Config{
-		Entrypoint:         DefaultEntrypoint,
 		StateDirectoryName: DefaultStateDirectoryName,
 		Orchestrator:       DefaultOrchestrator,
 		GrpcServerPort:     DefaultGrpcServerPort,
+
+		Entrypoint: Entrypoint{
+			HostEntrypointPath:      DefaultHostEntrypoint,
+			ContainerEntrypointPath: DefaultContainerEntrypoint,
+		},
 
 		Logging: LoggingConfig{
 			Enabled: DefaultLoggingEnabled,

--- a/internal/pkg/solo/config/config_test.go
+++ b/internal/pkg/solo/config/config_test.go
@@ -11,14 +11,14 @@ func TestConfigLoading(t *testing.T) {
 	config, err := NewConfig()
 
 	assert.Nil(err, "Failed to load config without error: %v", err)
-	assert.Equal(DefaultEntrypoint, config.Entrypoint, "Entrypoint does not match default")
+	assert.Equal(DefaultHostEntrypoint, config.Entrypoint.HostEntrypointPath, "Entrypoint does not match default")
 	assert.Equal(DefaultStateDirectoryName, config.StateDirectoryName, "StateDirectoryName does not match default")
 
 	if err := config.AddConfigPath("test/data/config"); err != nil {
 		assert.Fail("failed to add config path: %v", err)
 	}
 
-	assert.Equal("/opt/bin/solo-custom-entrypoint.sh", config.Entrypoint, "Entrypoint %s does not match overridden config")
+	assert.Equal("/opt/bin/solo-custom-entrypoint.sh", config.Entrypoint.HostEntrypointPath, "Entrypoint %s does not match overridden config")
 	assert.Equal("/opt/solo", config.StateDirectoryName, "StateDirectoryName %s does not match overridden config")
 }
 
@@ -28,13 +28,13 @@ func TestConfigPathNotFound(t *testing.T) {
 
 	assert.Nil(err, "Failed to load config without error: %v", err)
 
-	assert.Equal(DefaultEntrypoint, config.Entrypoint, "Entrypoint does not match default")
+	assert.Equal(DefaultHostEntrypoint, config.Entrypoint.HostEntrypointPath, "Entrypoint does not match default")
 	assert.Equal(DefaultStateDirectoryName, config.StateDirectoryName, "StateDirectoryName does not match default")
 
 	if err := config.AddConfigPath("test/data/config/notfound"); err != nil {
 		assert.Fail("failed to add config path: %v", err)
 	}
 
-	assert.Equal(DefaultEntrypoint, config.Entrypoint, "Entrypoint does not match default")
+	assert.Equal(DefaultHostEntrypoint, config.Entrypoint.HostEntrypointPath, "Entrypoint does not match default")
 	assert.Equal(DefaultStateDirectoryName, config.StateDirectoryName, "StateDirectoryName does not match default")
 }

--- a/internal/pkg/solo/container/docker.go
+++ b/internal/pkg/solo/container/docker.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"path"
 )
 
 type DockerOrchestrator struct {
@@ -128,7 +129,7 @@ func (t *DockerOrchestrator) GetHostGatewayHostname() string {
 }
 
 func (t *DockerOrchestrator) ExportComposeConfiguration(config *config.Config, project *project.Project) ([]byte, error) {
-	soloEntrypoint := config.Entrypoint
+	soloEntrypoint := path.Join(project.GetStateDirectoryRoot(), "solo-entrypoint")
 
 	allServicesDataPath := project.GetAllServicesStateDirectory()
 	_, err := os.Stat(allServicesDataPath)
@@ -148,7 +149,7 @@ func (t *DockerOrchestrator) ExportComposeConfiguration(config *config.Config, p
 			service.Command = append(service.Entrypoint, service.Command...)
 		}
 
-		service.Entrypoint = []string{"/usr/local/sbin/solo", "entrypoint"}
+		service.Entrypoint = []string{config.Entrypoint.ContainerEntrypointPath, "entrypoint"}
 
 		serviceLogPath := project.GetServiceLogDirectory(service.Name)
 		_, err := os.Stat(serviceLogPath)
@@ -178,7 +179,7 @@ func (t *DockerOrchestrator) ExportComposeConfiguration(config *config.Config, p
 		service.Volumes = append(service.Volumes, types.ServiceVolumeConfig{
 			Type:     "bind",
 			Source:   soloEntrypoint,
-			Target:   "/usr/local/sbin/solo",
+			Target:   config.Entrypoint.ContainerEntrypointPath,
 			ReadOnly: true,
 		}, types.ServiceVolumeConfig{
 			Type:     "bind",

--- a/internal/pkg/solo/project_control.go
+++ b/internal/pkg/solo/project_control.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spaulg/solo/internal/pkg/solo/context"
 	"github.com/spaulg/solo/internal/pkg/solo/events"
 	"github.com/spaulg/solo/internal/pkg/solo/grpc"
+	"io"
 	"os"
 	"path"
 )
@@ -70,6 +71,10 @@ func (t *ProjectControl) Start() error {
 	t.workflowManager.Subscribe(guard)
 	defer t.workflowManager.Unsubscribe(guard)
 
+	if err := t.copyEntrypointToState(); err != nil {
+		return err
+	}
+
 	// Write compose file
 	if exists, _ := t.composeFileExists(); !exists {
 		composeYml, _ := orchestrator.ExportComposeConfiguration(t.soloCtx.Config, t.soloCtx.Project)
@@ -92,7 +97,7 @@ func (t *ProjectControl) Start() error {
 	}
 
 	// Exec post start commands
-	postStartCommand := []string{"/usr/local/sbin/solo", "trigger-event", "post_start"}
+	postStartCommand := []string{t.soloCtx.Config.Entrypoint.ContainerEntrypointPath, "trigger-event", "post_start"}
 
 	if err := orchestrator.Execute(serviceNames, postStartCommand); err != nil {
 		return fmt.Errorf("error running compose: %v", err)
@@ -150,7 +155,7 @@ func (t *ProjectControl) Stop() error {
 		defer t.workflowManager.Unsubscribe(guard)
 
 		// Exec pre stop commands
-		preStopCommand := []string{"/usr/local/sbin/solo", "trigger-event", "pre_stop"}
+		preStopCommand := []string{t.soloCtx.Config.Entrypoint.ContainerEntrypointPath, "trigger-event", "pre_stop"}
 
 		if err := orchestrator.Execute(serviceNames, preStopCommand); err != nil {
 			return fmt.Errorf("error running compose: %v", err)
@@ -213,7 +218,7 @@ func (t *ProjectControl) Destroy() error {
 		defer t.workflowManager.Unsubscribe(guard)
 
 		// Exec pre destroy commands
-		preDestroyCommand := []string{"/usr/local/sbin/solo", "trigger-event", "pre_destroy"}
+		preDestroyCommand := []string{t.soloCtx.Config.Entrypoint.ContainerEntrypointPath, "trigger-event", "pre_destroy"}
 
 		if err := orchestrator.Execute(serviceNames, preDestroyCommand); err != nil {
 			return fmt.Errorf("error running compose: %v", err)
@@ -302,4 +307,32 @@ func (t *ProjectControl) buildWorkflowServiceMap(serviceNames []string, workflow
 	}
 
 	return workflowMap, nil
+}
+
+func (t *ProjectControl) copyEntrypointToState() error {
+	src := t.soloCtx.Config.Entrypoint.HostEntrypointPath
+	dst := path.Join(t.soloCtx.Project.GetStateDirectoryRoot(), "solo-entrypoint")
+
+	sourceFile, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+
+	destFile, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+
+	if _, err := io.Copy(destFile, sourceFile); err != nil {
+		return err
+	}
+
+	sourceFile.Close()
+	destFile.Close()
+
+	if err := os.Chmod(dst, 0755); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/solo-config.yml
+++ b/solo-config.yml
@@ -1,3 +1,12 @@
-Entrypoint: './cmd/solo-entrypoint/solo-entrypoint-wrapper.sh'
-Logging:
-  Level: debug
+#state_directory_name: ".solo"
+#orchestrator: "docker"
+#grpc_server_port: 0
+
+entrypoint:
+  host_entrypoint_path: "./cmd/solo-entrypoint/solo-entrypoint-wrapper.sh"
+  #container_entrypoint_path: "/usr/local/sbin/solo"
+
+logging:
+  #enabled: true
+  level: "debug"
+  #handler: text

--- a/test/data/config/solo-config.yml
+++ b/test/data/config/solo-config.yml
@@ -1,2 +1,4 @@
-Entrypoint: '/opt/bin/solo-custom-entrypoint.sh'
-StateDirectoryName: '/opt/solo'
+state_directory_name: '/opt/solo'
+
+entrypoint:
+  host_entrypoint_path: "/opt/bin/solo-custom-entrypoint.sh"


### PR DESCRIPTION
Use the entrypoint binary from the state directory to fix compose security restrictions which require bind mounts from the project directory.