### PR TITLE
Set logging config defaults to enabled

### DIFF
--- a/internal/pkg/solo/config/config.go
+++ b/internal/pkg/solo/config/config.go
@@ -16,7 +16,6 @@ type Config struct {
 
 	Entrypoint         string
 	StateDirectoryName string
-	ComposeFileName    string
 	Orchestrator       string
 	GrpcServerPort     uint16
 	Logging            LoggingConfig
@@ -27,10 +26,9 @@ const (
 	DefaultStateDirectoryName = "./.solo"
 	DefaultOrchestrator       = "docker"
 	DefaultGrpcServerPort     = 0
-	DefaultLoggingEnabled     = false
+	DefaultLoggingEnabled     = true
 	DefaultLoggingLevel       = "warning"
 	DefaultLoggingHandler     = "text"
-	DefaultComposeFileName    = "docker-compose.yml"
 )
 
 func NewConfig() (*Config, error) {
@@ -39,7 +37,6 @@ func NewConfig() (*Config, error) {
 		StateDirectoryName: DefaultStateDirectoryName,
 		Orchestrator:       DefaultOrchestrator,
 		GrpcServerPort:     DefaultGrpcServerPort,
-		ComposeFileName:    DefaultComposeFileName,
 
 		Logging: LoggingConfig{
 			Enabled: DefaultLoggingEnabled,

--- a/internal/pkg/solo/project/project.go
+++ b/internal/pkg/solo/project/project.go
@@ -16,15 +16,16 @@ import (
 	"time"
 )
 
+const generatedComposeFileName = "docker-compose.yml"
+
 type compose = types.Project
 
 type Project struct {
 	*compose
 
-	projectStateDirectory    string
-	generatedComposeFilepath string
-	directory                string
-	filePath                 string
+	projectStateDirectory string
+	directory             string
+	filePath              string
 }
 
 func NewProject(projectFilePath string, config *config.Config) (*Project, error) {
@@ -47,11 +48,10 @@ func NewProject(projectFilePath string, config *config.Config) (*Project, error)
 
 	projectDirectory := filepath.Dir(projectFilePath)
 	project := &Project{
-		projectStateDirectory:    path.Join(projectDirectory, config.StateDirectoryName),
-		generatedComposeFilepath: config.ComposeFileName,
-		directory:                projectDirectory,
-		filePath:                 projectFilePath,
-		compose:                  compose,
+		projectStateDirectory: path.Join(projectDirectory, config.StateDirectoryName),
+		directory:             projectDirectory,
+		filePath:              projectFilePath,
+		compose:               compose,
 	}
 
 	// Set default values in extensions
@@ -116,7 +116,7 @@ func (t *Project) GetServiceWorkflow(serviceName string, eventName string) Servi
 }
 
 func (t *Project) GetGeneratedComposeFilePath() string {
-	return path.Join(t.projectStateDirectory, t.generatedComposeFilepath)
+	return path.Join(t.projectStateDirectory, generatedComposeFileName)
 }
 
 func (t *Project) GetMaxWorkflowTimeout(eventName string) time.Duration {

--- a/solo-config.yml
+++ b/solo-config.yml
@@ -1,4 +1,3 @@
 Entrypoint: './cmd/solo-entrypoint/solo-entrypoint-wrapper.sh'
 Logging:
-  Enabled: true
   Level: debug


### PR DESCRIPTION
Set logging config defaults to enabled

Also delete the docker compose filename override when generating the compose file used in the state directory.