### PR TITLE
Apply pre_destroy commands to running containers only

### DIFF
--- a/internal/pkg/impl/host/project_control.go
+++ b/internal/pkg/impl/host/project_control.go
@@ -174,9 +174,9 @@ func (t *ProjectControl) Stop() error {
 
 		defer grpcServer.Stop()
 
-		// Populate a list of container names that will be started
-		servicesToStart := serviceStatus.RunningServices
-		containerNames, err := t.soloCtx.Project.ContainerNames(servicesToStart)
+		// Populate a list of container names that will be stopped
+		servicesToStop := serviceStatus.RunningServices
+		containerNames, err := t.soloCtx.Project.ContainerNames(servicesToStop)
 		if err != nil {
 			return fmt.Errorf("failed to convert service names to container names: %w", err)
 		}
@@ -248,9 +248,9 @@ func (t *ProjectControl) Destroy() error {
 
 		defer grpcServer.Stop()
 
-		// Populate a list of container names that will be started
-		servicesToStart := append(serviceStatus.RunningServices, append(serviceStatus.StoppedServices, serviceStatus.ExitedServices...)...)
-		containerNames, err := t.soloCtx.Project.ContainerNames(servicesToStart)
+		// Populate a list of container names that will be destroyed
+		servicesToDestroy := serviceStatus.RunningServices
+		containerNames, err := t.soloCtx.Project.ContainerNames(servicesToDestroy)
 		if err != nil {
 			return fmt.Errorf("failed to convert service names to container names: %w", err)
 		}


### PR DESCRIPTION
Apply pre_destroy commands to running containers only. Don't include stopped and exited containers, since these cannot be used with docker compose exec to run commands on, causing solo to exit with a failure.