### PR TITLE
Only attempt project load for commands that require projects

### DIFF
--- a/cmd/solo/subcommand/clean.go
+++ b/cmd/solo/subcommand/clean.go
@@ -14,10 +14,11 @@ func NewCleanSubCommand(soloCtx *context.CliContext) *cobra.Command {
 	var cleanCmdYes bool
 
 	cleanCmd := &cobra.Command{
-		Use:     "clean",
-		GroupID: "lifecycle",
-		Short:   "Clean the app",
-		Long:    "Clean the app",
+		Use:         "clean",
+		GroupID:     "lifecycle",
+		Short:       "Clean the app",
+		Long:        "Clean the app",
+		Annotations: map[string]string{LoadProjectFileAnnotation: "true"},
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if !cleanCmdYes {
 				var cmdConfirmationString string

--- a/cmd/solo/subcommand/destroy.go
+++ b/cmd/solo/subcommand/destroy.go
@@ -14,10 +14,11 @@ func NewDestroySubCommand(soloCtx *context.CliContext) *cobra.Command {
 	var destroyCmdYes bool
 
 	destroyCmd := &cobra.Command{
-		Use:     "destroy",
-		GroupID: "lifecycle",
-		Short:   "Destroys your app",
-		Long:    "Destroys your app",
+		Use:         "destroy",
+		GroupID:     "lifecycle",
+		Short:       "Destroys your app",
+		Long:        "Destroys your app",
+		Annotations: map[string]string{LoadProjectFileAnnotation: "true"},
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if !destroyCmdYes {
 				var cmdConfirmationString string

--- a/cmd/solo/subcommand/dumpComposeConfig.go
+++ b/cmd/solo/subcommand/dumpComposeConfig.go
@@ -11,10 +11,11 @@ import (
 
 func NewDumpComposeConfigCommand(soloCtx *context.CliContext) *cobra.Command {
 	return &cobra.Command{
-		Use:     "dump-compose-config",
-		GroupID: "config",
-		Short:   "Dumps the compose config to stdout",
-		Long:    "Dumps the compose config to stdout",
+		Use:         "dump-compose-config",
+		GroupID:     "config",
+		Short:       "Dumps the compose config to stdout",
+		Long:        "Dumps the compose config to stdout",
+		Annotations: map[string]string{LoadProjectFileAnnotation: "true"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			eventManager := events.GetEventManagerInstance()
 			orchestrator, err := container.NewOrchestratorFactory(soloCtx, eventManager).Build()

--- a/cmd/solo/subcommand/dumpConfig.go
+++ b/cmd/solo/subcommand/dumpConfig.go
@@ -10,10 +10,11 @@ import (
 
 func NewDumpConfigCommand(soloCtx *context.CliContext) *cobra.Command {
 	return &cobra.Command{
-		Use:     "dump-config",
-		GroupID: "config",
-		Short:   "Dumps the solo config to stdout",
-		Long:    "Dumps the solo config to stdout",
+		Use:         "dump-config",
+		GroupID:     "config",
+		Short:       "Dumps the solo config to stdout",
+		Long:        "Dumps the solo config to stdout",
+		Annotations: map[string]string{LoadProjectFileAnnotation: "true"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			configYaml, err := yaml.Marshal(soloCtx.Config)
 			if err != nil {

--- a/cmd/solo/subcommand/logs.go
+++ b/cmd/solo/subcommand/logs.go
@@ -9,10 +9,11 @@ import (
 
 func NewLogsCommand(_ *context.CliContext) *cobra.Command {
 	return &cobra.Command{
-		Use:     "logs",
-		GroupID: "tooling",
-		Short:   "Displays logs for your app",
-		Long:    "Displays logs for your app",
+		Use:         "logs",
+		GroupID:     "tooling",
+		Short:       "Displays logs for your app",
+		Long:        "Displays logs for your app",
+		Annotations: map[string]string{LoadProjectFileAnnotation: "true"},
 		Run: func(cmd *cobra.Command, args []string) {
 			fmt.Println("logs called")
 		},

--- a/cmd/solo/subcommand/rebuild.go
+++ b/cmd/solo/subcommand/rebuild.go
@@ -14,10 +14,11 @@ func NewRebuildCommand(soloCtx *context.CliContext) *cobra.Command {
 	var rebuildCmdYes bool
 
 	rebuildCmd := &cobra.Command{
-		Use:     "rebuild",
-		GroupID: "lifecycle",
-		Short:   "Rebuilds your app from scratch, preserving data",
-		Long:    "Rebuilds your app from scratch, preserving data",
+		Use:         "rebuild",
+		GroupID:     "lifecycle",
+		Short:       "Rebuilds your app from scratch, preserving data",
+		Long:        "Rebuilds your app from scratch, preserving data",
+		Annotations: map[string]string{LoadProjectFileAnnotation: "true"},
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if !rebuildCmdYes {
 				var cmdConfirmationString string

--- a/cmd/solo/subcommand/restart.go
+++ b/cmd/solo/subcommand/restart.go
@@ -8,10 +8,11 @@ import (
 
 func NewRestartCommand(soloCtx *context.CliContext) *cobra.Command {
 	return &cobra.Command{
-		Use:     "restart",
-		GroupID: "lifecycle",
-		Short:   "Restarts your app",
-		Long:    "Restarts your app",
+		Use:         "restart",
+		GroupID:     "lifecycle",
+		Short:       "Restarts your app",
+		Long:        "Restarts your app",
+		Annotations: map[string]string{LoadProjectFileAnnotation: "true"},
 		RunE: soloCtx.ProtectWithLock(func(cmd *cobra.Command, args []string) error {
 			projectControl, err := host.ProjectControlFactory(soloCtx)
 			if err != nil {

--- a/cmd/solo/subcommand/root.go
+++ b/cmd/solo/subcommand/root.go
@@ -13,6 +13,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const LoadProjectFileAnnotation = "LoadProjectFile"
+
 func Execute() {
 	cobra.EnableCommandSorting = false
 
@@ -53,6 +55,14 @@ func NewRootCommand(soloCtx *context.CliContext) *cobra.Command {
 		Use:          "solo",
 		SilenceUsage: true,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			if cmd.Annotations == nil || cmd.Annotations[LoadProjectFileAnnotation] != "true" {
+				return nil
+			}
+			
+			if soloCtx.ConfigLoadErr == nil {
+				soloCtx.ReloadProject()
+			}
+
 			if soloCtx.ProjectLoadErr != nil {
 				fmt.Println(soloCtx.ProjectLoadErr)
 				os.Exit(1)

--- a/cmd/solo/subcommand/ssh.go
+++ b/cmd/solo/subcommand/ssh.go
@@ -18,6 +18,7 @@ and usage of using your command. For example:
 Cobra is a CLI library for Go that empowers applications.
 This application is a tool to generate the needed files
 to quickly create a Cobra application.`,
+		Annotations: map[string]string{LoadProjectFileAnnotation: "true"},
 		Run: func(cmd *cobra.Command, args []string) {
 			fmt.Println("ssh called")
 		},

--- a/cmd/solo/subcommand/start.go
+++ b/cmd/solo/subcommand/start.go
@@ -8,10 +8,11 @@ import (
 
 func NewStartCommand(soloCtx *context.CliContext) *cobra.Command {
 	return &cobra.Command{
-		Use:     "start",
-		GroupID: "lifecycle",
-		Short:   "Starts your app",
-		Long:    "Starts your app",
+		Use:         "start",
+		GroupID:     "lifecycle",
+		Short:       "Starts your app",
+		Long:        "Starts your app",
+		Annotations: map[string]string{LoadProjectFileAnnotation: "true"},
 		RunE: soloCtx.ProtectWithLock(func(cmd *cobra.Command, args []string) error {
 			projectControl, err := host.ProjectControlFactory(soloCtx)
 			if err != nil {

--- a/cmd/solo/subcommand/stop.go
+++ b/cmd/solo/subcommand/stop.go
@@ -8,10 +8,11 @@ import (
 
 func NewStopCommand(soloCtx *context.CliContext) *cobra.Command {
 	return &cobra.Command{
-		Use:     "stop",
-		GroupID: "lifecycle",
-		Short:   "Stops your app",
-		Long:    "Stops your app",
+		Use:         "stop",
+		GroupID:     "lifecycle",
+		Short:       "Stops your app",
+		Long:        "Stops your app",
+		Annotations: map[string]string{LoadProjectFileAnnotation: "true"},
 		RunE: soloCtx.ProtectWithLock(func(cmd *cobra.Command, args []string) error {
 			projectControl, err := host.ProjectControlFactory(soloCtx)
 			if err != nil {

--- a/internal/pkg/impl/host/context/cli_context.go
+++ b/internal/pkg/impl/host/context/cli_context.go
@@ -42,7 +42,6 @@ func LoadCliContext() *CliContext {
 
 	if configLoadErr == nil {
 		context.Config = context.configReader.GetConfig()
-		context.ReloadProject()
 	}
 
 	return context


### PR DESCRIPTION
Only attempt project load for commands that require projects. Shell completions and the version command do not require a project and so can skip this.