### PR TITLE
Use correct working directory when running workflow steps

### DIFF
--- a/examples/symfony-webapp/Dockerfile.php
+++ b/examples/symfony-webapp/Dockerfile.php
@@ -4,3 +4,5 @@ RUN echo "deb http://deb.debian.org/debian bookworm-backports main" >> /etc/apt/
 RUN apt update -y
 RUN apt install -y golang-1.23 ca-certificates
 RUN ln -s /usr/lib/go-1.23/bin/go /usr/local/bin/go
+
+WORKDIR "/var/www"

--- a/examples/symfony-webapp/solo.yml
+++ b/examples/symfony-webapp/solo.yml
@@ -44,7 +44,7 @@ services:
 
           - name: composer install
             run: composer install
-            cwd: /var/www/project
+            working_directory: /var/www/project
 
   mail:
     profiles: ["mail"]

--- a/internal/pkg/impl/host/container/docker.go
+++ b/internal/pkg/impl/host/container/docker.go
@@ -30,7 +30,10 @@ type ComposeServiceStatus struct {
 }
 
 type DockerInspect struct {
-	Name string `json:"Name"`
+	Name   string `json:"Name"`
+	Config struct {
+		WorkingDir string `json:"WorkingDir"`
+	} `json:"Config"`
 }
 
 type DockerOrchestrator struct {
@@ -395,6 +398,37 @@ func (t *DockerOrchestrator) ResolveContainerNameFromMetadata(md metadata.MD) (s
 	return t.resolveContainerNameFromIdOrName(containerNames[0])
 }
 
+func (t *DockerOrchestrator) ResolveImageWorkingDirectory(serviceName string) (string, error) {
+	composeCmd := exec.Command(t.dockerCommandPath,
+		"compose",
+		"-f", t.composeFile,
+		"--project-directory", t.projectDirectory,
+		"images",
+		"-q",
+		serviceName,
+	)
+
+	var stdoutBuf bytes.Buffer
+	composeCmd.Stdout = &stdoutBuf
+
+	if err := composeCmd.Run(); err != nil {
+		return "", fmt.Errorf("failed to lookup image from service %s: %w", serviceName, err)
+	}
+
+	imageNameOrId := strings.TrimSpace(stdoutBuf.String())
+	inspect, err := t.dockerInspect("image", imageNameOrId)
+	if err != nil {
+		return "", fmt.Errorf("failed to inspect image %s: %w", imageNameOrId, err)
+	}
+
+	workingDirectory := "/"
+	if inspect.Config.WorkingDir != "" {
+		workingDirectory = inspect.Config.WorkingDir
+	}
+
+	return workingDirectory, nil
+}
+
 func (t *DockerOrchestrator) ResolveContainerNameFromServiceName(serviceName string, index int) (string, error) {
 	service := t.soloCtx.Project.Services().GetService(serviceName).GetConfig()
 	replicas := 1
@@ -414,10 +448,22 @@ func (t *DockerOrchestrator) ResolveContainerNameFromServiceName(serviceName str
 }
 
 func (t *DockerOrchestrator) resolveContainerNameFromIdOrName(containerNameOrId string) (string, error) {
+	inspect, err := t.dockerInspect("container", containerNameOrId)
+	if err != nil {
+		return "", fmt.Errorf("failed to inspect container %s: %w", containerNameOrId, err)
+	}
+
+	containerName := inspect.Name
+	containerName = strings.TrimLeft(containerName, "/")
+
+	return containerName, nil
+}
+
+func (t *DockerOrchestrator) dockerInspect(artifactName string, nameOrId string) (*DockerInspect, error) {
 	composeCmd := exec.Command(t.dockerCommandPath, "inspect",
 		"--format", "{{ json . }}",
-		"--type", "container",
-		containerNameOrId,
+		"--type", artifactName,
+		nameOrId,
 	)
 
 	var stdoutBuf bytes.Buffer
@@ -425,17 +471,14 @@ func (t *DockerOrchestrator) resolveContainerNameFromIdOrName(containerNameOrId 
 
 	if err := composeCmd.Run(); err != nil {
 		t.soloCtx.Logger.Error("Failed to run")
-		return "", err
+		return nil, err
 	}
 
 	inspect := DockerInspect{}
 	if err := json.Unmarshal(stdoutBuf.Bytes(), &inspect); err != nil {
 		t.soloCtx.Logger.Error("Failed to unmarshall")
-		return "", err
+		return nil, err
 	}
 
-	containerName := inspect.Name
-	containerName = strings.TrimLeft(containerName, "/")
-
-	return containerName, nil
+	return &inspect, nil
 }

--- a/internal/pkg/impl/host/grpc/asynchronous_server.go
+++ b/internal/pkg/impl/host/grpc/asynchronous_server.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/spaulg/solo/internal/pkg/impl/common/grpc/services"
 	"github.com/spaulg/solo/internal/pkg/impl/host/grpc/interceptors"
-	"github.com/spaulg/solo/internal/pkg/impl/host/grpc/service_definitions"
 	container_types "github.com/spaulg/solo/internal/pkg/types/host/container"
 	grpc_types "github.com/spaulg/solo/internal/pkg/types/host/grpc"
 )
@@ -26,7 +25,7 @@ type AsynchronousServer struct {
 	port                 uint32
 	stateDirectory       string
 	transportCredentials credentials.TransportCredentials
-	workflowService      *service_definitions.WorkflowServerImpl
+	workflowService      services.WorkflowServer
 	server               *grpc.Server
 	grpcServiceErrorCh   chan error
 }
@@ -36,7 +35,7 @@ func NewAsynchronousServer(
 	port int,
 	stateDirectory string,
 	transportCredentials credentials.TransportCredentials,
-	workflowService *service_definitions.WorkflowServerImpl,
+	workflowService services.WorkflowServer,
 ) grpc_types.Server {
 	return &AsynchronousServer{
 		orchestrator:         orchestrator,

--- a/internal/pkg/impl/host/grpc/mutual_tls_server_factory.go
+++ b/internal/pkg/impl/host/grpc/mutual_tls_server_factory.go
@@ -12,25 +12,34 @@ import (
 	"google.golang.org/grpc/credentials"
 
 	"github.com/spaulg/solo/internal/pkg/impl/host/certificate"
+	"github.com/spaulg/solo/internal/pkg/impl/host/context"
 	"github.com/spaulg/solo/internal/pkg/impl/host/grpc/service_definitions"
 	certificate_types "github.com/spaulg/solo/internal/pkg/types/host/certificate"
 	container_types "github.com/spaulg/solo/internal/pkg/types/host/container"
+	events_types "github.com/spaulg/solo/internal/pkg/types/host/events"
 	grpc_types "github.com/spaulg/solo/internal/pkg/types/host/grpc"
 	project_types "github.com/spaulg/solo/internal/pkg/types/host/project"
+	wms_types "github.com/spaulg/solo/internal/pkg/types/host/wms"
 )
 
 type MutualTLSServerFactory struct {
+	soloCtx              *context.CliContext
+	eventManager         events_types.Manager
+	workflowFactory      wms_types.WorkflowFactory
 	certificateAuthority certificate_types.Authority
-	workflowService      *service_definitions.WorkflowServerImpl
 }
 
 func NewMutualTLSServerFactory(
+	soloCtx *context.CliContext,
+	eventManager events_types.Manager,
+	workflowFactory wms_types.WorkflowFactory,
 	certificateAuthority certificate_types.Authority,
-	workflowService *service_definitions.WorkflowServerImpl,
 ) grpc_types.ServerFactory {
 	return &MutualTLSServerFactory{
+		soloCtx:              soloCtx,
+		eventManager:         eventManager,
+		workflowFactory:      workflowFactory,
 		certificateAuthority: certificateAuthority,
-		workflowService:      workflowService,
 	}
 }
 
@@ -46,12 +55,19 @@ func (t *MutualTLSServerFactory) Build(
 		return nil, err
 	}
 
+	workflowService := service_definitions.NewWorkflowService(
+		t.soloCtx,
+		t.eventManager,
+		orchestrator,
+		t.workflowFactory,
+	)
+
 	return NewAsynchronousServer(
 		orchestrator,
 		port,
 		project.GetAllServicesStateDirectory(),
 		transportCredentials,
-		t.workflowService,
+		workflowService,
 	), nil
 }
 

--- a/internal/pkg/impl/host/grpc/service_definitions/workflow.go
+++ b/internal/pkg/impl/host/grpc/service_definitions/workflow.go
@@ -10,6 +10,7 @@ import (
 	commonworkflow "github.com/spaulg/solo/internal/pkg/impl/common/wms"
 	"github.com/spaulg/solo/internal/pkg/impl/host/context"
 	"github.com/spaulg/solo/internal/pkg/impl/host/grpc/interceptors"
+	container_types "github.com/spaulg/solo/internal/pkg/types/host/container"
 	events_types "github.com/spaulg/solo/internal/pkg/types/host/events"
 	wms_types "github.com/spaulg/solo/internal/pkg/types/host/wms"
 )
@@ -18,17 +19,20 @@ type WorkflowServerImpl struct {
 	soloCtx *context.CliContext
 	services.UnimplementedWorkflowServer
 	eventManager    events_types.Manager
+	orchestrator    container_types.Orchestrator
 	workflowFactory wms_types.WorkflowFactory
 }
 
 func NewWorkflowService(
 	soloCtx *context.CliContext,
 	eventManager events_types.Manager,
+	orchestrator container_types.Orchestrator,
 	workflowFactory wms_types.WorkflowFactory,
 ) *WorkflowServerImpl {
 	return &WorkflowServerImpl{
 		soloCtx:         soloCtx,
 		eventManager:    eventManager,
+		orchestrator:    orchestrator,
 		workflowFactory: workflowFactory,
 	}
 }
@@ -133,7 +137,10 @@ func (t WorkflowServerImpl) applyWorkflowStream(
 		},
 	})
 
-	workflow := t.workflowFactory.Make(t.soloCtx.Project, serviceName, workflowName)
+	workflow, err := t.workflowFactory.Make(t.soloCtx.Project, t.orchestrator, serviceName, workflowName)
+	if err != nil {
+		return false, fmt.Errorf("failed to create workflow: %w", err)
+	}
 
 	if workflow != nil {
 		for step := range workflow.StepIterator() {

--- a/internal/pkg/impl/host/grpc/service_definitions/workflow_test.go
+++ b/internal/pkg/impl/host/grpc/service_definitions/workflow_test.go
@@ -1,10 +1,10 @@
 package service_definitions
 
 import (
-	"errors"
-	"testing"
-	"log/slog"
 	"context"
+	"errors"
+	"log/slog"
+	"testing"
 
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
@@ -17,6 +17,7 @@ import (
 	wms_types "github.com/spaulg/solo/internal/pkg/types/host/wms"
 	"github.com/spaulg/solo/test"
 	"github.com/spaulg/solo/test/mocks/grpc"
+	"github.com/spaulg/solo/test/mocks/host/container"
 	"github.com/spaulg/solo/test/mocks/host/events"
 	"github.com/spaulg/solo/test/mocks/host/logging"
 	"github.com/spaulg/solo/test/mocks/host/project"
@@ -30,21 +31,23 @@ func TestWorkflowTestSuite(t *testing.T) {
 type WorkflowTestSuite struct {
 	suite.Suite
 
-	soloCtx             *cli_context.CliContext
-	mockProject         *project.MockProject
-	mockLogHandler      *logging.MockHandler
-	mockEventManager    *events.MockEventManager
-	mockOrchestrator    *wms.MockOrchestrator
-	mockWorkflowFactory *wms.MockWorkflowFactory
-	mockGrpcServer      *grpc.MockBidiStreamingServer[services.WorkflowStreamRequest, services.WorkflowStreamResponse]
+	soloCtx                  *cli_context.CliContext
+	mockProject              *project.MockProject
+	mockLogHandler           *logging.MockHandler
+	mockEventManager         *events.MockEventManager
+	mockWorkflowOrchestrator *wms.MockOrchestrator
+	mockWorkflowFactory      *wms.MockWorkflowFactory
+	mockGrpcServer           *grpc.MockBidiStreamingServer[services.WorkflowStreamRequest, services.WorkflowStreamResponse]
+	mockOrchestrator         *container.MockOrchestrator
 }
 
 func (t *WorkflowTestSuite) SetupTest() {
 	t.mockEventManager = &events.MockEventManager{}
-	t.mockOrchestrator = &wms.MockOrchestrator{}
+	t.mockWorkflowOrchestrator = &wms.MockOrchestrator{}
 	t.mockWorkflowFactory = &wms.MockWorkflowFactory{}
 	t.mockProject = &project.MockProject{}
 	t.mockGrpcServer = &grpc.MockBidiStreamingServer[services.WorkflowStreamRequest, services.WorkflowStreamResponse]{}
+	t.mockOrchestrator = &container.MockOrchestrator{}
 
 	t.mockLogHandler = &logging.MockHandler{}
 	t.mockLogHandler.On("Enabled", mock.Anything, mock.Anything).Return(true)
@@ -74,7 +77,7 @@ func (t *WorkflowTestSuite) TestMissingServiceName() {
 		return record.Message == "Service name not found"
 	})).Return(nil)
 
-	workflowService := NewWorkflowService(t.soloCtx, t.mockEventManager, t.mockWorkflowFactory)
+	workflowService := NewWorkflowService(t.soloCtx, t.mockEventManager, t.mockOrchestrator, t.mockWorkflowFactory)
 	err := workflowService.FirstPreStartWorkflowStream(t.mockGrpcServer)
 
 	t.Error(err, "unauthorized")
@@ -82,7 +85,7 @@ func (t *WorkflowTestSuite) TestMissingServiceName() {
 	t.mockLogHandler.AssertExpectations(t.T())
 	t.mockEventManager.AssertExpectations(t.T())
 	t.mockWorkflowFactory.AssertExpectations(t.T())
-	t.mockOrchestrator.AssertExpectations(t.T())
+	t.mockWorkflowOrchestrator.AssertExpectations(t.T())
 	t.mockGrpcServer.AssertExpectations(t.T())
 }
 
@@ -98,7 +101,7 @@ func (t *WorkflowTestSuite) TestMissingContainerName() {
 		return record.Message == "Container name not found"
 	})).Return(nil)
 
-	workflowService := NewWorkflowService(t.soloCtx, t.mockEventManager, t.mockWorkflowFactory)
+	workflowService := NewWorkflowService(t.soloCtx, t.mockEventManager, t.mockOrchestrator, t.mockWorkflowFactory)
 	err := workflowService.FirstPreStartWorkflowStream(t.mockGrpcServer)
 
 	t.Error(err, "unauthorized")
@@ -106,7 +109,7 @@ func (t *WorkflowTestSuite) TestMissingContainerName() {
 	t.mockLogHandler.AssertExpectations(t.T())
 	t.mockEventManager.AssertExpectations(t.T())
 	t.mockWorkflowFactory.AssertExpectations(t.T())
-	t.mockOrchestrator.AssertExpectations(t.T())
+	t.mockWorkflowOrchestrator.AssertExpectations(t.T())
 	t.mockGrpcServer.AssertExpectations(t.T())
 }
 
@@ -128,7 +131,7 @@ func (t *WorkflowTestSuite) TestNilWorkflowFromFactory() {
 		},
 	}).Return()
 
-	t.mockWorkflowFactory.On("Make", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	t.mockWorkflowFactory.On("Make", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, nil)
 
 	t.mockEventManager.On("Publish", &wms_types.WorkflowCompleteEvent{
 		BaseWorkflowEvent: wms_types.BaseWorkflowEvent{
@@ -144,12 +147,12 @@ func (t *WorkflowTestSuite) TestNilWorkflowFromFactory() {
 		RunCommand: nil,
 	}).Return(nil)
 
-	workflowService := NewWorkflowService(t.soloCtx, t.mockEventManager, t.mockWorkflowFactory)
+	workflowService := NewWorkflowService(t.soloCtx, t.mockEventManager, t.mockOrchestrator, t.mockWorkflowFactory)
 	_ = workflowService.PreStartWorkflowStream(t.mockGrpcServer)
 
 	t.mockEventManager.AssertExpectations(t.T())
 	t.mockWorkflowFactory.AssertExpectations(t.T())
-	t.mockOrchestrator.AssertExpectations(t.T())
+	t.mockWorkflowOrchestrator.AssertExpectations(t.T())
 	t.mockGrpcServer.AssertExpectations(t.T())
 }
 
@@ -179,252 +182,252 @@ func (t *WorkflowTestSuite) TestFirstPreStartSkippedWorkflowStepTrigger() {
 		RunCommand: nil,
 	}).Return(nil)
 
-	workflowService := NewWorkflowService(t.soloCtx, t.mockEventManager, t.mockWorkflowFactory)
+	workflowService := NewWorkflowService(t.soloCtx, t.mockEventManager, t.mockOrchestrator, t.mockWorkflowFactory)
 	_ = workflowService.FirstPreStartWorkflowStream(t.mockGrpcServer)
 
 	t.mockEventManager.AssertExpectations(t.T())
 	t.mockWorkflowFactory.AssertExpectations(t.T())
-	t.mockOrchestrator.AssertExpectations(t.T())
+	t.mockWorkflowOrchestrator.AssertExpectations(t.T())
 	t.mockGrpcServer.AssertExpectations(t.T())
 }
 
 func (t *WorkflowTestSuite) TestFirstPreStartRecvError() {
 	t.testServerRecvErrorFor(commonworkflow.FirstPreStart)
 
-	workflowService := NewWorkflowService(t.soloCtx, t.mockEventManager, t.mockWorkflowFactory)
+	workflowService := NewWorkflowService(t.soloCtx, t.mockEventManager, t.mockOrchestrator, t.mockWorkflowFactory)
 	_ = workflowService.FirstPreStartWorkflowStream(t.mockGrpcServer)
 
 	t.mockEventManager.AssertExpectations(t.T())
 	t.mockWorkflowFactory.AssertExpectations(t.T())
-	t.mockOrchestrator.AssertExpectations(t.T())
+	t.mockWorkflowOrchestrator.AssertExpectations(t.T())
 	t.mockGrpcServer.AssertExpectations(t.T())
 }
 
 func (t *WorkflowTestSuite) TestPreStartRecvError() {
 	t.testServerRecvErrorFor(commonworkflow.PreStart)
 
-	workflowService := NewWorkflowService(t.soloCtx, t.mockEventManager, t.mockWorkflowFactory)
+	workflowService := NewWorkflowService(t.soloCtx, t.mockEventManager, t.mockOrchestrator, t.mockWorkflowFactory)
 	_ = workflowService.PreStartWorkflowStream(t.mockGrpcServer)
 
 	t.mockEventManager.AssertExpectations(t.T())
 	t.mockWorkflowFactory.AssertExpectations(t.T())
-	t.mockOrchestrator.AssertExpectations(t.T())
+	t.mockWorkflowOrchestrator.AssertExpectations(t.T())
 	t.mockGrpcServer.AssertExpectations(t.T())
 }
 
 func (t *WorkflowTestSuite) TestPostStartRecvError() {
 	t.testServerRecvErrorFor(commonworkflow.PostStart)
 
-	workflowService := NewWorkflowService(t.soloCtx, t.mockEventManager, t.mockWorkflowFactory)
+	workflowService := NewWorkflowService(t.soloCtx, t.mockEventManager, t.mockOrchestrator, t.mockWorkflowFactory)
 	_ = workflowService.PostStartWorkflowStream(t.mockGrpcServer)
 
 	t.mockEventManager.AssertExpectations(t.T())
 	t.mockWorkflowFactory.AssertExpectations(t.T())
-	t.mockOrchestrator.AssertExpectations(t.T())
+	t.mockWorkflowOrchestrator.AssertExpectations(t.T())
 	t.mockGrpcServer.AssertExpectations(t.T())
 }
 
 func (t *WorkflowTestSuite) TestPreStopRecvError() {
 	t.testServerRecvErrorFor(commonworkflow.PreStop)
 
-	workflowService := NewWorkflowService(t.soloCtx, t.mockEventManager, t.mockWorkflowFactory)
+	workflowService := NewWorkflowService(t.soloCtx, t.mockEventManager, t.mockOrchestrator, t.mockWorkflowFactory)
 	_ = workflowService.PreStopWorkflowStream(t.mockGrpcServer)
 
 	t.mockEventManager.AssertExpectations(t.T())
 	t.mockWorkflowFactory.AssertExpectations(t.T())
-	t.mockOrchestrator.AssertExpectations(t.T())
+	t.mockWorkflowOrchestrator.AssertExpectations(t.T())
 	t.mockGrpcServer.AssertExpectations(t.T())
 }
 
 func (t *WorkflowTestSuite) TestPreDestroyRecvError() {
 	t.testServerRecvErrorFor(commonworkflow.PreDestroy)
 
-	workflowService := NewWorkflowService(t.soloCtx, t.mockEventManager, t.mockWorkflowFactory)
+	workflowService := NewWorkflowService(t.soloCtx, t.mockEventManager, t.mockOrchestrator, t.mockWorkflowFactory)
 	_ = workflowService.PreDestroyWorkflowStream(t.mockGrpcServer)
 
 	t.mockEventManager.AssertExpectations(t.T())
 	t.mockWorkflowFactory.AssertExpectations(t.T())
-	t.mockOrchestrator.AssertExpectations(t.T())
+	t.mockWorkflowOrchestrator.AssertExpectations(t.T())
 	t.mockGrpcServer.AssertExpectations(t.T())
 }
 
 func (t *WorkflowTestSuite) TestFirstPreStartUnknownWorkflowResult() {
 	t.testUnknownWorkflowResult(commonworkflow.FirstPreStart)
 
-	workflowService := NewWorkflowService(t.soloCtx, t.mockEventManager, t.mockWorkflowFactory)
+	workflowService := NewWorkflowService(t.soloCtx, t.mockEventManager, t.mockOrchestrator, t.mockWorkflowFactory)
 	_ = workflowService.FirstPreStartWorkflowStream(t.mockGrpcServer)
 
 	t.mockEventManager.AssertExpectations(t.T())
 	t.mockWorkflowFactory.AssertExpectations(t.T())
-	t.mockOrchestrator.AssertExpectations(t.T())
+	t.mockWorkflowOrchestrator.AssertExpectations(t.T())
 	t.mockGrpcServer.AssertExpectations(t.T())
 }
 
 func (t *WorkflowTestSuite) TestPreStartUnknownWorkflowResult() {
 	t.testUnknownWorkflowResult(commonworkflow.PreStart)
 
-	workflowService := NewWorkflowService(t.soloCtx, t.mockEventManager, t.mockWorkflowFactory)
+	workflowService := NewWorkflowService(t.soloCtx, t.mockEventManager, t.mockOrchestrator, t.mockWorkflowFactory)
 	_ = workflowService.PreStartWorkflowStream(t.mockGrpcServer)
 
 	t.mockEventManager.AssertExpectations(t.T())
 	t.mockWorkflowFactory.AssertExpectations(t.T())
-	t.mockOrchestrator.AssertExpectations(t.T())
+	t.mockWorkflowOrchestrator.AssertExpectations(t.T())
 	t.mockGrpcServer.AssertExpectations(t.T())
 }
 
 func (t *WorkflowTestSuite) TestPostStartUnknownWorkflowResult() {
 	t.testUnknownWorkflowResult(commonworkflow.PostStart)
 
-	workflowService := NewWorkflowService(t.soloCtx, t.mockEventManager, t.mockWorkflowFactory)
+	workflowService := NewWorkflowService(t.soloCtx, t.mockEventManager, t.mockOrchestrator, t.mockWorkflowFactory)
 	_ = workflowService.PostStartWorkflowStream(t.mockGrpcServer)
 
 	t.mockEventManager.AssertExpectations(t.T())
 	t.mockWorkflowFactory.AssertExpectations(t.T())
-	t.mockOrchestrator.AssertExpectations(t.T())
+	t.mockWorkflowOrchestrator.AssertExpectations(t.T())
 	t.mockGrpcServer.AssertExpectations(t.T())
 }
 
 func (t *WorkflowTestSuite) TestPreStopUnknownWorkflowResult() {
 	t.testUnknownWorkflowResult(commonworkflow.PreStop)
 
-	workflowService := NewWorkflowService(t.soloCtx, t.mockEventManager, t.mockWorkflowFactory)
+	workflowService := NewWorkflowService(t.soloCtx, t.mockEventManager, t.mockOrchestrator, t.mockWorkflowFactory)
 	_ = workflowService.PreStopWorkflowStream(t.mockGrpcServer)
 
 	t.mockEventManager.AssertExpectations(t.T())
 	t.mockWorkflowFactory.AssertExpectations(t.T())
-	t.mockOrchestrator.AssertExpectations(t.T())
+	t.mockWorkflowOrchestrator.AssertExpectations(t.T())
 	t.mockGrpcServer.AssertExpectations(t.T())
 }
 
 func (t *WorkflowTestSuite) TestPreDestroyUnknownWorkflowResult() {
 	t.testUnknownWorkflowResult(commonworkflow.PreDestroy)
 
-	workflowService := NewWorkflowService(t.soloCtx, t.mockEventManager, t.mockWorkflowFactory)
+	workflowService := NewWorkflowService(t.soloCtx, t.mockEventManager, t.mockOrchestrator, t.mockWorkflowFactory)
 	_ = workflowService.PreDestroyWorkflowStream(t.mockGrpcServer)
 
 	t.mockEventManager.AssertExpectations(t.T())
 	t.mockWorkflowFactory.AssertExpectations(t.T())
-	t.mockOrchestrator.AssertExpectations(t.T())
+	t.mockWorkflowOrchestrator.AssertExpectations(t.T())
 	t.mockGrpcServer.AssertExpectations(t.T())
 }
 
 func (t *WorkflowTestSuite) TestFirstPreStartZeroWorkflowStepTrigger() {
 	t.testWorkflowExecFor(commonworkflow.FirstPreStart, 0)
 
-	workflowService := NewWorkflowService(t.soloCtx, t.mockEventManager, t.mockWorkflowFactory)
+	workflowService := NewWorkflowService(t.soloCtx, t.mockEventManager, t.mockOrchestrator, t.mockWorkflowFactory)
 	_ = workflowService.FirstPreStartWorkflowStream(t.mockGrpcServer)
 
 	t.mockEventManager.AssertExpectations(t.T())
 	t.mockWorkflowFactory.AssertExpectations(t.T())
-	t.mockOrchestrator.AssertExpectations(t.T())
+	t.mockWorkflowOrchestrator.AssertExpectations(t.T())
 	t.mockGrpcServer.AssertExpectations(t.T())
 }
 
 func (t *WorkflowTestSuite) TestPreStartZeroWorkflowStepTrigger() {
 	t.testWorkflowExecFor(commonworkflow.PreStart, 0)
 
-	workflowService := NewWorkflowService(t.soloCtx, t.mockEventManager, t.mockWorkflowFactory)
+	workflowService := NewWorkflowService(t.soloCtx, t.mockEventManager, t.mockOrchestrator, t.mockWorkflowFactory)
 	_ = workflowService.PreStartWorkflowStream(t.mockGrpcServer)
 
 	t.mockEventManager.AssertExpectations(t.T())
 	t.mockWorkflowFactory.AssertExpectations(t.T())
-	t.mockOrchestrator.AssertExpectations(t.T())
+	t.mockWorkflowOrchestrator.AssertExpectations(t.T())
 	t.mockGrpcServer.AssertExpectations(t.T())
 }
 
 func (t *WorkflowTestSuite) TestPostStartZeroWorkflowStepTrigger() {
 	t.testWorkflowExecFor(commonworkflow.PostStart, 0)
 
-	workflowService := NewWorkflowService(t.soloCtx, t.mockEventManager, t.mockWorkflowFactory)
+	workflowService := NewWorkflowService(t.soloCtx, t.mockEventManager, t.mockOrchestrator, t.mockWorkflowFactory)
 	_ = workflowService.PostStartWorkflowStream(t.mockGrpcServer)
 
 	t.mockEventManager.AssertExpectations(t.T())
 	t.mockWorkflowFactory.AssertExpectations(t.T())
-	t.mockOrchestrator.AssertExpectations(t.T())
+	t.mockWorkflowOrchestrator.AssertExpectations(t.T())
 	t.mockGrpcServer.AssertExpectations(t.T())
 }
 
 func (t *WorkflowTestSuite) TestPreStopZeroWorkflowStepTrigger() {
 	t.testWorkflowExecFor(commonworkflow.PreStop, 0)
 
-	workflowService := NewWorkflowService(t.soloCtx, t.mockEventManager, t.mockWorkflowFactory)
+	workflowService := NewWorkflowService(t.soloCtx, t.mockEventManager, t.mockOrchestrator, t.mockWorkflowFactory)
 	_ = workflowService.PreStopWorkflowStream(t.mockGrpcServer)
 
 	t.mockEventManager.AssertExpectations(t.T())
 	t.mockWorkflowFactory.AssertExpectations(t.T())
-	t.mockOrchestrator.AssertExpectations(t.T())
+	t.mockWorkflowOrchestrator.AssertExpectations(t.T())
 	t.mockGrpcServer.AssertExpectations(t.T())
 }
 
 func (t *WorkflowTestSuite) TestPreDestroyZeroWorkflowStepTrigger() {
 	t.testWorkflowExecFor(commonworkflow.PreDestroy, 0)
 
-	workflowService := NewWorkflowService(t.soloCtx, t.mockEventManager, t.mockWorkflowFactory)
+	workflowService := NewWorkflowService(t.soloCtx, t.mockEventManager, t.mockOrchestrator, t.mockWorkflowFactory)
 	_ = workflowService.PreDestroyWorkflowStream(t.mockGrpcServer)
 
 	t.mockEventManager.AssertExpectations(t.T())
 	t.mockWorkflowFactory.AssertExpectations(t.T())
-	t.mockOrchestrator.AssertExpectations(t.T())
+	t.mockWorkflowOrchestrator.AssertExpectations(t.T())
 	t.mockGrpcServer.AssertExpectations(t.T())
 }
 
 func (t *WorkflowTestSuite) TestFirstPreStartNonZeroWorkflowStepTrigger() {
 	t.testWorkflowExecFor(commonworkflow.FirstPreStart, 10)
 
-	workflowService := NewWorkflowService(t.soloCtx, t.mockEventManager, t.mockWorkflowFactory)
+	workflowService := NewWorkflowService(t.soloCtx, t.mockEventManager, t.mockOrchestrator, t.mockWorkflowFactory)
 	_ = workflowService.FirstPreStartWorkflowStream(t.mockGrpcServer)
 
 	t.mockEventManager.AssertExpectations(t.T())
 	t.mockWorkflowFactory.AssertExpectations(t.T())
-	t.mockOrchestrator.AssertExpectations(t.T())
+	t.mockWorkflowOrchestrator.AssertExpectations(t.T())
 	t.mockGrpcServer.AssertExpectations(t.T())
 }
 
 func (t *WorkflowTestSuite) TestPreStartNonZeroWorkflowStepTrigger() {
 	t.testWorkflowExecFor(commonworkflow.PreStart, 10)
 
-	workflowService := NewWorkflowService(t.soloCtx, t.mockEventManager, t.mockWorkflowFactory)
+	workflowService := NewWorkflowService(t.soloCtx, t.mockEventManager, t.mockOrchestrator, t.mockWorkflowFactory)
 	_ = workflowService.PreStartWorkflowStream(t.mockGrpcServer)
 
 	t.mockEventManager.AssertExpectations(t.T())
 	t.mockWorkflowFactory.AssertExpectations(t.T())
-	t.mockOrchestrator.AssertExpectations(t.T())
+	t.mockWorkflowOrchestrator.AssertExpectations(t.T())
 	t.mockGrpcServer.AssertExpectations(t.T())
 }
 
 func (t *WorkflowTestSuite) TestPostStartNonZeroWorkflowStepTrigger() {
 	t.testWorkflowExecFor(commonworkflow.PostStart, 10)
 
-	workflowService := NewWorkflowService(t.soloCtx, t.mockEventManager, t.mockWorkflowFactory)
+	workflowService := NewWorkflowService(t.soloCtx, t.mockEventManager, t.mockOrchestrator, t.mockWorkflowFactory)
 	_ = workflowService.PostStartWorkflowStream(t.mockGrpcServer)
 
 	t.mockEventManager.AssertExpectations(t.T())
 	t.mockWorkflowFactory.AssertExpectations(t.T())
-	t.mockOrchestrator.AssertExpectations(t.T())
+	t.mockWorkflowOrchestrator.AssertExpectations(t.T())
 	t.mockGrpcServer.AssertExpectations(t.T())
 }
 
 func (t *WorkflowTestSuite) TestPreStopNonZeroWorkflowStepTrigger() {
 	t.testWorkflowExecFor(commonworkflow.PreStop, 10)
 
-	workflowService := NewWorkflowService(t.soloCtx, t.mockEventManager, t.mockWorkflowFactory)
+	workflowService := NewWorkflowService(t.soloCtx, t.mockEventManager, t.mockOrchestrator, t.mockWorkflowFactory)
 	_ = workflowService.PreStopWorkflowStream(t.mockGrpcServer)
 
 	t.mockEventManager.AssertExpectations(t.T())
 	t.mockWorkflowFactory.AssertExpectations(t.T())
-	t.mockOrchestrator.AssertExpectations(t.T())
+	t.mockWorkflowOrchestrator.AssertExpectations(t.T())
 	t.mockGrpcServer.AssertExpectations(t.T())
 }
 
 func (t *WorkflowTestSuite) TestPreDestroyNonZeroWorkflowStepTrigger() {
 	t.testWorkflowExecFor(commonworkflow.PreDestroy, 10)
 
-	workflowService := NewWorkflowService(t.soloCtx, t.mockEventManager, t.mockWorkflowFactory)
+	workflowService := NewWorkflowService(t.soloCtx, t.mockEventManager, t.mockOrchestrator, t.mockWorkflowFactory)
 	_ = workflowService.PreDestroyWorkflowStream(t.mockGrpcServer)
 
 	t.mockEventManager.AssertExpectations(t.T())
 	t.mockWorkflowFactory.AssertExpectations(t.T())
-	t.mockOrchestrator.AssertExpectations(t.T())
+	t.mockWorkflowOrchestrator.AssertExpectations(t.T())
 	t.mockGrpcServer.AssertExpectations(t.T())
 }
 
@@ -446,9 +449,9 @@ func (t *WorkflowTestSuite) testWorkflowExecFor(workflow commonworkflow.Workflow
 		},
 	}).Return()
 
-	t.mockWorkflowFactory.On("Make", mock.Anything, mock.Anything, mock.Anything).Return(t.mockOrchestrator)
+	t.mockWorkflowFactory.On("Make", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(t.mockWorkflowOrchestrator, nil)
 
-	t.mockOrchestrator.On("StepIterator").Return(func(yield func(wms_types.Step) bool) {
+	t.mockWorkflowOrchestrator.On("StepIterator").Return(func(yield func(wms_types.Step) bool) {
 		step := &wms.MockStep{}
 		step.On("GetId").Return("12345")
 		step.On("GetName").Return("test")
@@ -569,9 +572,9 @@ func (t *WorkflowTestSuite) testServerRecvErrorFor(workflow commonworkflow.Workf
 		},
 	}).Return()
 
-	t.mockWorkflowFactory.On("Make", mock.Anything, mock.Anything, mock.Anything).Return(t.mockOrchestrator)
+	t.mockWorkflowFactory.On("Make", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(t.mockWorkflowOrchestrator, nil)
 
-	t.mockOrchestrator.On("StepIterator").Return(func(yield func(wms_types.Step) bool) {
+	t.mockWorkflowOrchestrator.On("StepIterator").Return(func(yield func(wms_types.Step) bool) {
 		step := &wms.MockStep{}
 		step.On("GetId").Return("12345")
 		step.On("GetName").Return("test")
@@ -651,9 +654,9 @@ func (t *WorkflowTestSuite) testUnknownWorkflowResult(workflow commonworkflow.Wo
 		},
 	}).Return()
 
-	t.mockWorkflowFactory.On("Make", mock.Anything, mock.Anything, mock.Anything).Return(t.mockOrchestrator)
+	t.mockWorkflowFactory.On("Make", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(t.mockWorkflowOrchestrator, nil)
 
-	t.mockOrchestrator.On("StepIterator").Return(func(yield func(wms_types.Step) bool) {
+	t.mockWorkflowOrchestrator.On("StepIterator").Return(func(yield func(wms_types.Step) bool) {
 		step := &wms.MockStep{}
 		step.On("GetId").Return("12345")
 		step.On("GetName").Return("test")

--- a/internal/pkg/impl/host/project_control_factory.go
+++ b/internal/pkg/impl/host/project_control_factory.go
@@ -8,7 +8,6 @@ import (
 	"github.com/spaulg/solo/internal/pkg/impl/host/context"
 	"github.com/spaulg/solo/internal/pkg/impl/host/events"
 	"github.com/spaulg/solo/internal/pkg/impl/host/grpc"
-	"github.com/spaulg/solo/internal/pkg/impl/host/grpc/service_definitions"
 	"github.com/spaulg/solo/internal/pkg/impl/host/subscribers"
 	"github.com/spaulg/solo/internal/pkg/impl/host/wms"
 )
@@ -19,7 +18,6 @@ func ProjectControlFactory(soloCtx *context.CliContext) (*ProjectControl, error)
 	eventManager.Subscribe(subscribers.NewLogWriterEventSubscriber(soloCtx))
 
 	workflowFactory := wms.NewWorkflowFactory()
-	workflowService := service_definitions.NewWorkflowService(soloCtx, eventManager, workflowFactory)
 
 	// Container orchestrator factory
 	orchestratorFactory := container.NewOrchestratorFactory(soloCtx, eventManager)
@@ -30,7 +28,7 @@ func ProjectControlFactory(soloCtx *context.CliContext) (*ProjectControl, error)
 		return nil, fmt.Errorf("failed to initialize certificate authority: %w", err)
 	}
 
-	grpcServerFactory := grpc.NewMutualTLSServerFactory(certificateAuthority, workflowService)
+	grpcServerFactory := grpc.NewMutualTLSServerFactory(soloCtx, eventManager, workflowFactory, certificateAuthority)
 
 	workflowGuardFactory := wms.NewWorkflowGuardFactory(soloCtx)
 

--- a/internal/pkg/impl/host/wms/orchestrator.go
+++ b/internal/pkg/impl/host/wms/orchestrator.go
@@ -12,14 +12,17 @@ import (
 )
 
 type Orchestrator struct {
-	steps []compose_types.WorkflowStep
+	serviceWorkingDirectory string
+	steps                   []compose_types.WorkflowStep
 }
 
 func NewOrchestrator(
+	serviceWorkingDirectory string,
 	workflow compose_types.ServiceWorkflowConfig,
 ) wms_types.Orchestrator {
 	return &Orchestrator{
-		steps: workflow.Steps,
+		serviceWorkingDirectory: serviceWorkingDirectory,
+		steps:                   workflow.Steps,
 	}
 }
 
@@ -33,7 +36,12 @@ func (t *Orchestrator) StepIterator() iter.Seq[wms_types.Step] {
 		for stepNumber < stepCount {
 			id := ulid.MustNew(ulid.Timestamp(time.Now()), entropy)
 
-			step := NewStep(id.String(), t.steps[stepNumber].Name, t.steps[stepNumber].Run, t.steps[stepNumber].Cwd)
+			workingDirectory := t.serviceWorkingDirectory
+			if t.steps[stepNumber].WorkingDirectory != nil {
+				workingDirectory = *t.steps[stepNumber].WorkingDirectory
+			}
+
+			step := NewStep(id.String(), t.steps[stepNumber].Name, t.steps[stepNumber].Run, workingDirectory)
 			if !yield(step) {
 				return
 			}

--- a/internal/pkg/impl/host/wms/orchestrator_test.go
+++ b/internal/pkg/impl/host/wms/orchestrator_test.go
@@ -53,26 +53,26 @@ func (t *OrchestratorTestSuite) SetupTest() {
 	t.config = compose_types.ServiceWorkflowConfig{
 		Steps: []compose_types.WorkflowStep{
 			{
-				Name: "step1",
-				Run:  "/bin/foo arg1 arg2",
-				Cwd:  &cwd,
+				Name:             "step1",
+				Run:              "/bin/foo arg1 arg2",
+				WorkingDirectory: &cwd,
 			},
 			{
-				Name: "step2",
-				Run:  "/bin/bar arg3 arg4",
-				Cwd:  &cwd,
+				Name:             "step2",
+				Run:              "/bin/bar arg3 arg4",
+				WorkingDirectory: &cwd,
 			},
 			{
-				Name: "step3",
-				Run:  "/bin/baz arg5 arg6",
-				Cwd:  &cwd,
+				Name:             "step3",
+				Run:              "/bin/baz arg5 arg6",
+				WorkingDirectory: &cwd,
 			},
 		},
 	}
 }
 
 func (t *OrchestratorTestSuite) TestIteration() {
-	orchestrator := NewOrchestrator(t.config)
+	orchestrator := NewOrchestrator("/", t.config)
 
 	counter := 0
 	for step := range orchestrator.StepIterator() {
@@ -86,7 +86,7 @@ func (t *OrchestratorTestSuite) TestIteration() {
 }
 
 func (t *OrchestratorTestSuite) TestIterationWithEarlyBreak() {
-	orchestrator := NewOrchestrator(t.config)
+	orchestrator := NewOrchestrator("/", t.config)
 
 	counter := 0
 	for step := range orchestrator.StepIterator() {

--- a/internal/pkg/impl/host/wms/step.go
+++ b/internal/pkg/impl/host/wms/step.go
@@ -13,20 +13,15 @@ type Step struct {
 	workingDirectory string
 }
 
-func NewStep(id string, name string, command string, workingDirectory *string) wms_types.Step {
+func NewStep(id string, name string, command string, workingDirectory string) wms_types.Step {
 	command, arguments := cmd.SplitCommand(command)
-
-	cwd := "/"
-	if workingDirectory != nil {
-		cwd = *workingDirectory
-	}
 
 	return &Step{
 		id:               id,
 		name:             name,
 		command:          command,
 		arguments:        arguments,
-		workingDirectory: cwd,
+		workingDirectory: workingDirectory,
 	}
 }
 
@@ -50,7 +45,11 @@ func (t *Step) GetWorkingDirectory() string {
 	return t.workingDirectory
 }
 
-func (t *Step) Trigger(start wms_types.StepTriggerLambda, progress wms_types.StepProgressLambda, complete wms_types.StepCompleteLambda) error {
+func (t *Step) Trigger(
+	start wms_types.StepTriggerLambda,
+	progress wms_types.StepProgressLambda,
+	complete wms_types.StepCompleteLambda,
+) error {
 	// Start step
 	if err := start(); err != nil {
 		return err

--- a/internal/pkg/impl/host/wms/step_test.go
+++ b/internal/pkg/impl/host/wms/step_test.go
@@ -26,14 +26,14 @@ func (t *StepTestSuite) SetupTest() {
 }
 
 func (t *StepTestSuite) TestStepAccessors() {
-	step := NewStep(expectedStepId, expectedStepName, expectedStepCommand, &t.localWorkingDirectory)
+	step := NewStep(expectedStepId, expectedStepName, expectedStepCommand, t.localWorkingDirectory)
 
 	t.Equal(expectedStepName, step.GetName())
 	t.Equal(expectedWorkingDirectory, step.GetWorkingDirectory())
 }
 
 func (t *StepTestSuite) TestExecWithoutArg() {
-	step := NewStep(expectedStepId, expectedStepName, expectedStepCommand, &t.localWorkingDirectory)
+	step := NewStep(expectedStepId, expectedStepName, expectedStepCommand, t.localWorkingDirectory)
 
 	t.Equal(expectedStepName, step.GetName())
 	t.Equal(expectedStepCommand, step.GetCommand())
@@ -43,7 +43,7 @@ func (t *StepTestSuite) TestExecWithoutArg() {
 
 func (t *StepTestSuite) TestExecWithArg() {
 	command := "/bin/ls -lh"
-	step := NewStep(expectedStepId, expectedStepName, command, &t.localWorkingDirectory)
+	step := NewStep(expectedStepId, expectedStepName, command, t.localWorkingDirectory)
 
 	t.Equal("/bin/ls", step.GetCommand())
 	t.Equal([]string{"-lh"}, step.GetArguments())
@@ -51,7 +51,7 @@ func (t *StepTestSuite) TestExecWithArg() {
 
 func (t *StepTestSuite) TestExecWithDoubleQuotedArg() {
 	command := "/bin/ls -lh \"/path with space\""
-	step := NewStep(expectedStepId, expectedStepName, command, &t.localWorkingDirectory)
+	step := NewStep(expectedStepId, expectedStepName, command, t.localWorkingDirectory)
 
 	t.Equal("/bin/ls", step.GetCommand())
 	t.Equal([]string{"-lh", "/path with space"}, step.GetArguments())
@@ -59,7 +59,7 @@ func (t *StepTestSuite) TestExecWithDoubleQuotedArg() {
 
 func (t *StepTestSuite) TestExecWithSingleQuotedArg() {
 	command := "/bin/ls -lh '/path with space'"
-	step := NewStep(expectedStepId, expectedStepName, command, &t.localWorkingDirectory)
+	step := NewStep(expectedStepId, expectedStepName, command, t.localWorkingDirectory)
 
 	t.Equal("/bin/ls", step.GetCommand())
 	t.Equal([]string{"-lh", "/path with space"}, step.GetArguments())
@@ -67,7 +67,7 @@ func (t *StepTestSuite) TestExecWithSingleQuotedArg() {
 
 func (t *StepTestSuite) TestExecWithEscapedArg() {
 	command := "/bin/ls -lh /path\\ with\\ escaped\\ spaces"
-	step := NewStep(expectedStepId, expectedStepName, command, &t.localWorkingDirectory)
+	step := NewStep(expectedStepId, expectedStepName, command, t.localWorkingDirectory)
 
 	t.Equal("/bin/ls", step.GetCommand())
 	t.Equal([]string{"-lh", "/path with escaped spaces"}, step.GetArguments())
@@ -75,7 +75,7 @@ func (t *StepTestSuite) TestExecWithEscapedArg() {
 
 func (t *StepTestSuite) TestExecWithEscapedAndDoubleQuotedArg() {
 	command := "/bin/ls -lh /path\\ with\\ escaped\\ spaces \"/path with space\""
-	step := NewStep(expectedStepId, expectedStepName, command, &t.localWorkingDirectory)
+	step := NewStep(expectedStepId, expectedStepName, command, t.localWorkingDirectory)
 
 	t.Equal("/bin/ls", step.GetCommand())
 	t.Equal([]string{"-lh", "/path with escaped spaces", "/path with space"}, step.GetArguments())
@@ -83,7 +83,7 @@ func (t *StepTestSuite) TestExecWithEscapedAndDoubleQuotedArg() {
 
 func (t *StepTestSuite) TestExecWithEscapedAndSingleQuotedArg() {
 	command := "/bin/ls -lh /path\\ with\\ escaped\\ spaces '/path with space'"
-	step := NewStep(expectedStepId, expectedStepName, command, &t.localWorkingDirectory)
+	step := NewStep(expectedStepId, expectedStepName, command, t.localWorkingDirectory)
 
 	t.Equal("/bin/ls", step.GetCommand())
 	t.Equal([]string{"-lh", "/path with escaped spaces", "/path with space"}, step.GetArguments())
@@ -91,7 +91,7 @@ func (t *StepTestSuite) TestExecWithEscapedAndSingleQuotedArg() {
 
 func (t *StepTestSuite) TestExecWithEmptyDoubleQuotedArg() {
 	command := "/bin/ls -lh \"\""
-	step := NewStep(expectedStepId, expectedStepName, command, &t.localWorkingDirectory)
+	step := NewStep(expectedStepId, expectedStepName, command, t.localWorkingDirectory)
 
 	t.Equal("/bin/ls", step.GetCommand())
 	t.Equal([]string{"-lh", ""}, step.GetArguments())
@@ -99,7 +99,7 @@ func (t *StepTestSuite) TestExecWithEmptyDoubleQuotedArg() {
 
 func (t *StepTestSuite) TestExecWithEmptySingleQuotedArg() {
 	command := "/bin/ls -lh ''"
-	step := NewStep(expectedStepId, expectedStepName, command, &t.localWorkingDirectory)
+	step := NewStep(expectedStepId, expectedStepName, command, t.localWorkingDirectory)
 
 	t.Equal("/bin/ls", step.GetCommand())
 	t.Equal([]string{"-lh", ""}, step.GetArguments())
@@ -107,7 +107,7 @@ func (t *StepTestSuite) TestExecWithEmptySingleQuotedArg() {
 
 func (t *StepTestSuite) TestExecWithDoubleEscapedArg() {
 	command := "/bin/ls -lh /path\\\\ with\\\\ escaped\\\\ spaces"
-	step := NewStep(expectedStepId, expectedStepName, command, &t.localWorkingDirectory)
+	step := NewStep(expectedStepId, expectedStepName, command, t.localWorkingDirectory)
 
 	t.Equal("/bin/ls", step.GetCommand())
 	t.Equal([]string{"-lh", "/path\\", "with\\", "escaped\\", "spaces"}, step.GetArguments())
@@ -115,7 +115,7 @@ func (t *StepTestSuite) TestExecWithDoubleEscapedArg() {
 
 func (t *StepTestSuite) TestExecWithNestedEscapedDoubleQuotedArg() {
 	command := "/bin/ls -lh \"/path\\ with\\ space\""
-	step := NewStep(expectedStepId, expectedStepName, command, &t.localWorkingDirectory)
+	step := NewStep(expectedStepId, expectedStepName, command, t.localWorkingDirectory)
 
 	t.Equal("/bin/ls", step.GetCommand())
 	t.Equal([]string{"-lh", "/path\\ with\\ space"}, step.GetArguments())
@@ -123,7 +123,7 @@ func (t *StepTestSuite) TestExecWithNestedEscapedDoubleQuotedArg() {
 
 func (t *StepTestSuite) TestExecWithNestedEscapedSingleQuotedArg() {
 	command := "/bin/ls -lh '/path\\ with\\ space'"
-	step := NewStep(expectedStepId, expectedStepName, command, &t.localWorkingDirectory)
+	step := NewStep(expectedStepId, expectedStepName, command, t.localWorkingDirectory)
 
 	t.Equal("/bin/ls", step.GetCommand())
 	t.Equal([]string{"-lh", "/path\\ with\\ space"}, step.GetArguments())
@@ -131,7 +131,7 @@ func (t *StepTestSuite) TestExecWithNestedEscapedSingleQuotedArg() {
 
 func (t *StepTestSuite) TestExecWithEscapedDoubleQuoteArg() {
 	command := "/bin/ls -lh \\\"\\\""
-	step := NewStep(expectedStepId, expectedStepName, command, &t.localWorkingDirectory)
+	step := NewStep(expectedStepId, expectedStepName, command, t.localWorkingDirectory)
 
 	t.Equal("/bin/ls", step.GetCommand())
 	t.Equal([]string{"-lh", "\"\""}, step.GetArguments())
@@ -139,7 +139,7 @@ func (t *StepTestSuite) TestExecWithEscapedDoubleQuoteArg() {
 
 func (t *StepTestSuite) TestExecWithEscapedSingleQuoteArg() {
 	command := "/bin/ls -lh \\'\\'"
-	step := NewStep(expectedStepId, expectedStepName, command, &t.localWorkingDirectory)
+	step := NewStep(expectedStepId, expectedStepName, command, t.localWorkingDirectory)
 
 	t.Equal("/bin/ls", step.GetCommand())
 	t.Equal([]string{"-lh", "''"}, step.GetArguments())
@@ -147,7 +147,7 @@ func (t *StepTestSuite) TestExecWithEscapedSingleQuoteArg() {
 
 func (t *StepTestSuite) TestExecWithEscapedBackslashArg() {
 	command := "/bin/ls -lh \\\\"
-	step := NewStep(expectedStepId, expectedStepName, command, &t.localWorkingDirectory)
+	step := NewStep(expectedStepId, expectedStepName, command, t.localWorkingDirectory)
 
 	t.Equal("/bin/ls", step.GetCommand())
 	t.Equal([]string{"-lh", "\\"}, step.GetArguments())
@@ -155,7 +155,7 @@ func (t *StepTestSuite) TestExecWithEscapedBackslashArg() {
 
 func (t *StepTestSuite) TestExecWithQuotedEscapedSingleQuoteArg() {
 	command := "/bin/ls -lh \"\\'\""
-	step := NewStep(expectedStepId, expectedStepName, command, &t.localWorkingDirectory)
+	step := NewStep(expectedStepId, expectedStepName, command, t.localWorkingDirectory)
 
 	t.Equal("/bin/ls", step.GetCommand())
 	t.Equal([]string{"-lh", "\\'"}, step.GetArguments())
@@ -163,7 +163,7 @@ func (t *StepTestSuite) TestExecWithQuotedEscapedSingleQuoteArg() {
 
 func (t *StepTestSuite) TestShellWithoutArg() {
 	command := "ls"
-	step := NewStep(expectedStepId, expectedStepName, command, &t.localWorkingDirectory)
+	step := NewStep(expectedStepId, expectedStepName, command, t.localWorkingDirectory)
 
 	t.Equal("/bin/sh", step.GetCommand())
 	t.Equal([]string{"-c", "ls"}, step.GetArguments())
@@ -171,7 +171,7 @@ func (t *StepTestSuite) TestShellWithoutArg() {
 
 func (t *StepTestSuite) TestShellWithArg() {
 	command := "ls -lh"
-	step := NewStep(expectedStepId, expectedStepName, command, &t.localWorkingDirectory)
+	step := NewStep(expectedStepId, expectedStepName, command, t.localWorkingDirectory)
 
 	t.Equal("/bin/sh", step.GetCommand())
 	t.Equal([]string{"-c", "ls -lh"}, step.GetArguments())
@@ -179,7 +179,7 @@ func (t *StepTestSuite) TestShellWithArg() {
 
 func (t *StepTestSuite) TestShellWithDoubleQuotedArg() {
 	command := "ls -lh \"/path with space\""
-	step := NewStep(expectedStepId, expectedStepName, command, &t.localWorkingDirectory)
+	step := NewStep(expectedStepId, expectedStepName, command, t.localWorkingDirectory)
 
 	t.Equal("/bin/sh", step.GetCommand())
 	t.Equal([]string{"-c", "ls -lh \"/path with space\""}, step.GetArguments())
@@ -187,7 +187,7 @@ func (t *StepTestSuite) TestShellWithDoubleQuotedArg() {
 
 func (t *StepTestSuite) TestShellWithEscapedArg() {
 	command := "ls -lh /path\\ with\\ escaped\\ spaces"
-	step := NewStep(expectedStepId, expectedStepName, command, &t.localWorkingDirectory)
+	step := NewStep(expectedStepId, expectedStepName, command, t.localWorkingDirectory)
 
 	t.Equal("/bin/sh", step.GetCommand())
 	t.Equal([]string{"-c", "ls -lh /path\\ with\\ escaped\\ spaces"}, step.GetArguments())
@@ -195,7 +195,7 @@ func (t *StepTestSuite) TestShellWithEscapedArg() {
 
 func (t *StepTestSuite) TestShellWithEscapedAndDoubleQuotedArg() {
 	command := "ls -lh /path\\ with\\ escaped\\ spaces \"/path with space\""
-	step := NewStep(expectedStepId, expectedStepName, command, &t.localWorkingDirectory)
+	step := NewStep(expectedStepId, expectedStepName, command, t.localWorkingDirectory)
 
 	t.Equal("/bin/sh", step.GetCommand())
 	t.Equal([]string{"-c", "ls -lh /path\\ with\\ escaped\\ spaces \"/path with space\""}, step.GetArguments())
@@ -203,7 +203,7 @@ func (t *StepTestSuite) TestShellWithEscapedAndDoubleQuotedArg() {
 
 func (t *StepTestSuite) TestShellWithEmptyDoubleQuotedArg() {
 	command := "ls -lh \"\""
-	step := NewStep(expectedStepId, expectedStepName, command, &t.localWorkingDirectory)
+	step := NewStep(expectedStepId, expectedStepName, command, t.localWorkingDirectory)
 
 	t.Equal("/bin/sh", step.GetCommand())
 	t.Equal([]string{"-c", "ls -lh \"\""}, step.GetArguments())
@@ -211,7 +211,7 @@ func (t *StepTestSuite) TestShellWithEmptyDoubleQuotedArg() {
 
 func (t *StepTestSuite) TestShellWithDoubleEscapedArg() {
 	command := "ls -lh /path\\\\ with\\\\ escaped\\\\ spaces"
-	step := NewStep(expectedStepId, expectedStepName, command, &t.localWorkingDirectory)
+	step := NewStep(expectedStepId, expectedStepName, command, t.localWorkingDirectory)
 
 	t.Equal("/bin/sh", step.GetCommand())
 	t.Equal([]string{"-c", "ls -lh /path\\\\ with\\\\ escaped\\\\ spaces"}, step.GetArguments())
@@ -219,7 +219,7 @@ func (t *StepTestSuite) TestShellWithDoubleEscapedArg() {
 
 func (t *StepTestSuite) TestShellWithNestedEscapedDoubleQuotedArg() {
 	command := "ls -lh \"/path\\ with\\ space\""
-	step := NewStep(expectedStepId, expectedStepName, command, &t.localWorkingDirectory)
+	step := NewStep(expectedStepId, expectedStepName, command, t.localWorkingDirectory)
 
 	t.Equal("/bin/sh", step.GetCommand())
 	t.Equal([]string{"-c", "ls -lh \"/path\\ with\\ space\""}, step.GetArguments())

--- a/internal/pkg/impl/host/wms/workflow_factory.go
+++ b/internal/pkg/impl/host/wms/workflow_factory.go
@@ -2,6 +2,7 @@ package wms
 
 import (
 	workflowcommon "github.com/spaulg/solo/internal/pkg/impl/common/wms"
+	container_types "github.com/spaulg/solo/internal/pkg/types/host/container"
 	project_types "github.com/spaulg/solo/internal/pkg/types/host/project"
 	wms_types "github.com/spaulg/solo/internal/pkg/types/host/wms"
 )
@@ -14,8 +15,26 @@ func NewWorkflowFactory() wms_types.WorkflowFactory {
 
 func (t *WorkflowFactory) Make(
 	project project_types.Project,
+	orchestrator container_types.Orchestrator,
 	serviceName string,
 	workflowName workflowcommon.WorkflowName,
-) wms_types.Orchestrator {
-	return NewOrchestrator(project.Services().GetService(serviceName).GetServiceWorkflow(workflowName.String()))
+) (wms_types.Orchestrator, error) {
+	service := project.Services().GetService(serviceName)
+	var err error
+
+	// Use project context to lookup the services working_directory option
+	serviceWorkingDirectory := service.GetConfig().WorkingDir
+	if serviceWorkingDirectory == "" {
+		// Project does not define a working directory for the service
+		// Use orchestrator to lookup the working directory from the service image
+		serviceWorkingDirectory, err = orchestrator.ResolveImageWorkingDirectory(serviceName)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return NewOrchestrator(
+		serviceWorkingDirectory,
+		service.GetServiceWorkflow(workflowName.String()),
+	), nil
 }

--- a/internal/pkg/impl/host/wms/workflow_factory_test.go
+++ b/internal/pkg/impl/host/wms/workflow_factory_test.go
@@ -3,10 +3,12 @@ package wms
 import (
 	"testing"
 
+	"github.com/compose-spec/compose-go/v2/types"
 	"github.com/stretchr/testify/suite"
 
 	workflowcommon "github.com/spaulg/solo/internal/pkg/impl/common/wms"
 	compose_types "github.com/spaulg/solo/internal/pkg/types/host/project/compose"
+	"github.com/spaulg/solo/test/mocks/host/container"
 	"github.com/spaulg/solo/test/mocks/host/project"
 	"github.com/spaulg/solo/test/mocks/host/project/compose"
 )
@@ -18,11 +20,13 @@ func TestWorkflowFactoryTestSuite(t *testing.T) {
 type WorkflowFactoryTestSuite struct {
 	suite.Suite
 
-	mockProject *project.MockProject
+	mockProject      *project.MockProject
+	mockOrchestrator *container.MockOrchestrator
 }
 
 func (t *WorkflowFactoryTestSuite) SetupTest() {
 	t.mockProject = &project.MockProject{}
+	t.mockOrchestrator = &container.MockOrchestrator{}
 }
 
 func (t *WorkflowFactoryTestSuite) TestBuild() {
@@ -39,11 +43,15 @@ func (t *WorkflowFactoryTestSuite) TestBuild() {
 	t.mockProject.On("Services").Return(mockServices)
 	mockServices.On("GetService", serviceName).Return(mockServiceConfig)
 	mockServiceConfig.On("GetServiceWorkflow", workflowName.String()).Return(workflowConfig)
+	mockServiceConfig.On("GetConfig").Return(types.ServiceConfig{})
+
+	t.mockOrchestrator.On("ResolveImageWorkingDirectory", serviceName).Return("/", nil)
 
 	workflowFactory := NewWorkflowFactory()
-	workflow := workflowFactory.Make(t.mockProject, serviceName, workflowName)
+	workflow, err := workflowFactory.Make(t.mockProject, t.mockOrchestrator, serviceName, workflowName)
 
 	t.NotNil(workflow)
+	t.NoError(err)
 
 	t.mockProject.AssertExpectations(t.T())
 }

--- a/internal/pkg/types/host/container/orchestrator.go
+++ b/internal/pkg/types/host/container/orchestrator.go
@@ -20,4 +20,5 @@ type Orchestrator interface {
 	ExportComposeConfiguration(config *config_types.Config, project project_types.Project) ([]byte, error)
 	ResolveContainerNameFromMetadata(md metadata.MD) (string, error)
 	ResolveContainerNameFromServiceName(serviceName string, index int) (string, error)
+	ResolveImageWorkingDirectory(serviceName string) (string, error)
 }

--- a/internal/pkg/types/host/grpc/service_definitions/workflow_factory.go
+++ b/internal/pkg/types/host/grpc/service_definitions/workflow_factory.go
@@ -1,0 +1,10 @@
+package service_definitions
+
+import (
+	"github.com/spaulg/solo/internal/pkg/impl/common/grpc/services"
+	container_types "github.com/spaulg/solo/internal/pkg/types/host/container"
+)
+
+type WorkflowFactory interface {
+	Build(orchestrator container_types.Orchestrator) services.WorkflowServer
+}

--- a/internal/pkg/types/host/project/compose/service_workflow.go
+++ b/internal/pkg/types/host/project/compose/service_workflow.go
@@ -3,9 +3,9 @@ package compose
 import "github.com/compose-spec/compose-go/v2/types"
 
 type WorkflowStep struct {
-	Name string  `yaml:"name"`
-	Run  string  `yaml:"run"`
-	Cwd  *string `yaml:"cwd"`
+	Name             string  `yaml:"name"`
+	Run              string  `yaml:"run"`
+	WorkingDirectory *string `yaml:"working_dir"`
 }
 
 type ServiceWorkflowConfig struct {

--- a/internal/pkg/types/host/wms/workflow_factory.go
+++ b/internal/pkg/types/host/wms/workflow_factory.go
@@ -2,9 +2,15 @@ package wms
 
 import (
 	workflowcommon "github.com/spaulg/solo/internal/pkg/impl/common/wms"
+	container_types "github.com/spaulg/solo/internal/pkg/types/host/container"
 	project_types "github.com/spaulg/solo/internal/pkg/types/host/project"
 )
 
 type WorkflowFactory interface {
-	Make(project project_types.Project, service string, workflowName workflowcommon.WorkflowName) Orchestrator
+	Make(
+		project project_types.Project,
+		orchestrator container_types.Orchestrator,
+		service string,
+		workflowName workflowcommon.WorkflowName,
+	) (Orchestrator, error)
 }

--- a/solo.yml
+++ b/solo.yml
@@ -45,6 +45,7 @@ services:
       context: .
       dockerfile: ./examples/symfony-webapp/Dockerfile.php
     command: /usr/sbin/php-fpm8.4 -FO
+    working_dir: /var/www/project
     volumes:
       - "composer:/root/.cache/composer"
       - "./examples/symfony-webapp:/var/www/project"
@@ -76,7 +77,6 @@ services:
 
           - name: composer install
             run: composer install
-            cwd: /var/www/project
 
           - name: Update apt
             run: apt update -y

--- a/test/mocks/host/container/orchestrator.go
+++ b/test/mocks/host/container/orchestrator.go
@@ -84,3 +84,8 @@ func (m *MockOrchestrator) ResolveContainerNameFromServiceName(serviceName strin
 	args := m.Called(serviceName, index)
 	return args.String(0), args.Error(1)
 }
+
+func (m *MockOrchestrator) ResolveImageWorkingDirectory(service string) (string, error) {
+	args := m.Called(service)
+	return args.String(0), args.Error(1)
+}

--- a/test/mocks/host/wms/workflow_factory.go
+++ b/test/mocks/host/wms/workflow_factory.go
@@ -1,10 +1,12 @@
 package wms
 
 import (
+	"github.com/stretchr/testify/mock"
+
 	workflowcommon "github.com/spaulg/solo/internal/pkg/impl/common/wms"
+	container_types "github.com/spaulg/solo/internal/pkg/types/host/container"
 	project_types "github.com/spaulg/solo/internal/pkg/types/host/project"
 	wms_types "github.com/spaulg/solo/internal/pkg/types/host/wms"
-	"github.com/stretchr/testify/mock"
 )
 
 type MockWorkflowFactory struct {
@@ -13,13 +15,14 @@ type MockWorkflowFactory struct {
 
 func (m *MockWorkflowFactory) Make(
 	project project_types.Project,
+	orchestrator container_types.Orchestrator,
 	service string,
 	workflowName workflowcommon.WorkflowName,
-) wms_types.Orchestrator {
-	args := m.Called(project, service, workflowName)
+) (wms_types.Orchestrator, error) {
+	args := m.Called(project, orchestrator, service, workflowName)
 	if o, ok := args.Get(0).(wms_types.Orchestrator); ok {
-		return o
+		return o, args.Error(1)
 	} else {
-		return nil
+		return nil, args.Error(1)
 	}
 }


### PR DESCRIPTION
Use the working_directory of the step, the working_directory of the service, or the workdir of the service image, in this order, when running workflow steps.