### PR TITLE
Refactor GRPC workflow service to use a single rpc method

### DIFF
--- a/cmd/solo-entrypoint/subcommand/entrypoint.go
+++ b/cmd/solo-entrypoint/subcommand/entrypoint.go
@@ -29,12 +29,12 @@ func NewEntrypointCommand(entrypointCtx *context.EntrypointContext) *cobra.Comma
 			defer workflowRunner.Close()
 
 			if !isServiceBuilt() {
-				if err := workflowRunner.Execute(commonworkflow.FirstPreStart); err != nil {
+				if err := workflowRunner.Execute(commonworkflow.FirstPreStartContainer); err != nil {
 					panic(err)
 				}
 			}
 
-			if err := workflowRunner.Execute(commonworkflow.PreStart); err != nil {
+			if err := workflowRunner.Execute(commonworkflow.PreStartContainer); err != nil {
 				panic(err)
 			}
 
@@ -62,7 +62,7 @@ func forkAndExecute(args []string) error {
 }
 
 func isServiceBuilt() bool {
-	markerFile := "/solo/service/data/first_pre_start_complete"
+	markerFile := "/solo/service/data/first_pre_start_container_complete"
 
 	if _, err := os.Stat(markerFile); err != nil {
 		return false

--- a/examples/symfony-webapp/solo.yml
+++ b/examples/symfony-webapp/solo.yml
@@ -26,7 +26,7 @@ services:
       replicas: 3
 
     x-workflows:
-      first_pre_start:
+      first_pre_start_container:
         timeout: 180s
 
         steps:

--- a/internal/pkg/impl/common/grpc/services/workflow.proto
+++ b/internal/pkg/impl/common/grpc/services/workflow.proto
@@ -3,6 +3,17 @@ package services;
 
 option go_package = "github.com/spaulg/solo/internal/pkg/impl/common/grpc/services";
 
+message RunWorkflowStreamRequest {
+  oneof request {
+      WorkflowRunRequest run_request = 1;
+      WorkflowStreamRequest stream_request = 2;
+  }
+}
+
+message WorkflowRunRequest {
+  string workflow_name = 1;
+}
+
 message WorkflowStreamResponse {
   WorkflowAction action = 1;
   optional WorkflowRunCommand run_command = 2;
@@ -37,9 +48,5 @@ message WorkflowRunResult {
 }
 
 service Workflow {
-  rpc FirstPreStartWorkflowStream(stream WorkflowStreamRequest) returns (stream WorkflowStreamResponse);
-  rpc PreStartWorkflowStream(stream WorkflowStreamRequest) returns (stream WorkflowStreamResponse);
-  rpc PostStartWorkflowStream(stream WorkflowStreamRequest) returns (stream WorkflowStreamResponse);
-  rpc PreStopWorkflowStream(stream WorkflowStreamRequest) returns (stream WorkflowStreamResponse);
-  rpc PreDestroyWorkflowStream(stream WorkflowStreamRequest) returns (stream WorkflowStreamResponse);
+  rpc RunWorkflowStream(stream RunWorkflowStreamRequest) returns (stream WorkflowStreamResponse);
 }

--- a/internal/pkg/impl/common/wms/workflow_name.go
+++ b/internal/pkg/impl/common/wms/workflow_name.go
@@ -4,42 +4,38 @@ type WorkflowName int
 
 const (
 	Undefined WorkflowName = iota
-	FirstPreStart
-	PreStart
-	PostStart
-	PreStop
-	PostStop
-	PreDestroy
-	PostDestroy
+	FirstPreStartContainer
+	PreStartContainer
+	PostStartContainer
+	FirstPostStartContainer
+	PreStopContainer
+	PreDestroyContainer
 )
 
 // nolint:gochecknoglobals
 var WorkflowNames = []WorkflowName{
-	FirstPreStart,
-	PreStart,
-	PostStart,
-	PreStop,
-	PostStop,
-	PreDestroy,
-	PostDestroy,
+	FirstPreStartContainer,
+	PreStartContainer,
+	PostStartContainer,
+	FirstPostStartContainer,
+	PreStopContainer,
+	PreDestroyContainer,
 }
 
 func WorkflowNameFromString(name string) WorkflowName {
 	switch name {
-	case "first_pre_start":
-		return FirstPreStart
-	case "pre_start":
-		return PreStart
-	case "post_start":
-		return PostStart
-	case "pre_stop":
-		return PreStop
-	case "post_stop":
-		return PostStop
-	case "pre_destroy":
-		return PreDestroy
-	case "post_destroy":
-		return PostDestroy
+	case "first_pre_start_container":
+		return FirstPreStartContainer
+	case "pre_start_container":
+		return PreStartContainer
+	case "post_start_container":
+		return PostStartContainer
+	case "first_post_start_container":
+		return FirstPostStartContainer
+	case "pre_stop_container":
+		return PreStopContainer
+	case "pre_destroy_container":
+		return PreDestroyContainer
 	default:
 		return Undefined
 	}
@@ -47,20 +43,18 @@ func WorkflowNameFromString(name string) WorkflowName {
 
 func (c WorkflowName) String() string {
 	switch c {
-	case FirstPreStart:
-		return "first_pre_start"
-	case PreStart:
-		return "pre_start"
-	case PostStart:
-		return "post_start"
-	case PreStop:
-		return "pre_stop"
-	case PostStop:
-		return "post_stop"
-	case PreDestroy:
-		return "pre_destroy"
-	case PostDestroy:
-		return "post_destroy"
+	case FirstPreStartContainer:
+		return "first_pre_start_container"
+	case PreStartContainer:
+		return "pre_start_container"
+	case PostStartContainer:
+		return "post_start_container"
+	case FirstPostStartContainer:
+		return "first_post_start_container"
+	case PreStopContainer:
+		return "pre_stop_container"
+	case PreDestroyContainer:
+		return "pre_destroy_container"
 	default:
 		return "unknown"
 	}

--- a/internal/pkg/impl/common/wms/workflow_name_test.go
+++ b/internal/pkg/impl/common/wms/workflow_name_test.go
@@ -15,25 +15,33 @@ type WorkflowNameTestSuite struct {
 }
 
 func (t *WorkflowNameTestSuite) TestWorkflowNameFromString() {
-	t.Equal(FirstPreStart, WorkflowNameFromString("first_pre_start"))
-	t.Equal(PreStart, WorkflowNameFromString("pre_start"))
-	t.Equal(PostStart, WorkflowNameFromString("post_start"))
-	t.Equal(PreStop, WorkflowNameFromString("pre_stop"))
-	t.Equal(PostStop, WorkflowNameFromString("post_stop"))
-	t.Equal(PreDestroy, WorkflowNameFromString("pre_destroy"))
-	t.Equal(PostDestroy, WorkflowNameFromString("post_destroy"))
+	// Start
+	t.Equal(FirstPreStartContainer, WorkflowNameFromString("first_pre_start_container"))
+	t.Equal(PreStartContainer, WorkflowNameFromString("pre_start_container"))
+	t.Equal(PostStartContainer, WorkflowNameFromString("post_start_container"))
+	t.Equal(FirstPostStartContainer, WorkflowNameFromString("first_post_start_container"))
+
+	// Stop
+	t.Equal(PreStopContainer, WorkflowNameFromString("pre_stop_container"))
+
+	// Destroy
+	t.Equal(PreDestroyContainer, WorkflowNameFromString("pre_destroy_container"))
 
 	t.Equal(Undefined, WorkflowNameFromString("qwerty"))
 }
 
 func (t *WorkflowNameTestSuite) TestString() {
-	t.Equal("first_pre_start", FirstPreStart.String())
-	t.Equal("pre_start", PreStart.String())
-	t.Equal("post_start", PostStart.String())
-	t.Equal("pre_stop", PreStop.String())
-	t.Equal("post_stop", PostStop.String())
-	t.Equal("pre_destroy", PreDestroy.String())
-	t.Equal("post_destroy", PostDestroy.String())
+	// Start
+	t.Equal("first_pre_start_container", FirstPreStartContainer.String())
+	t.Equal("pre_start_container", PreStartContainer.String())
+	t.Equal("post_start_container", PostStartContainer.String())
+	t.Equal("first_post_start_container", FirstPostStartContainer.String())
+
+	// Stop
+	t.Equal("pre_stop_container", PreStopContainer.String())
+
+	// Destroy
+	t.Equal("pre_destroy_container", PreDestroyContainer.String())
 
 	t.Equal("unknown", Undefined.String())
 }

--- a/internal/pkg/impl/entrypoint/workflow/grpc_workflow_runner.go
+++ b/internal/pkg/impl/entrypoint/workflow/grpc_workflow_runner.go
@@ -8,16 +8,18 @@ import (
 	"os/exec"
 	"sync"
 
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+
 	"github.com/spaulg/solo/internal/pkg/impl/common/grpc/services"
 	commonworkflow "github.com/spaulg/solo/internal/pkg/impl/common/wms"
 	entrypointcontext "github.com/spaulg/solo/internal/pkg/impl/entrypoint/context"
 	grpc_credentials_types "github.com/spaulg/solo/internal/pkg/types/entrypoint/grpc/credentials"
 	workflow_types "github.com/spaulg/solo/internal/pkg/types/entrypoint/workflow"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/metadata"
 )
 
-const FirstPreStartCompleteMetadataKey = "first_pre_start_complete"
+const FirstPreStartContainerCompleteMetadataKey = "first_pre_start_container_complete"
+const FirstPostStartContainerCompleteMetadataKey = "first_post_start_container_complete"
 
 type GrpcWorkflowRunner struct {
 	entrypointCtx  *entrypointcontext.EntrypointContext
@@ -26,7 +28,7 @@ type GrpcWorkflowRunner struct {
 	metadataState  *MetadataState
 }
 
-type WorkflowStream grpc.BidiStreamingClient[services.WorkflowStreamRequest, services.WorkflowStreamResponse]
+type WorkflowStream grpc.BidiStreamingClient[services.RunWorkflowStreamRequest, services.WorkflowStreamResponse]
 
 func NewGrpcWorkflowRunner(
 	entrypointCtx *entrypointcontext.EntrypointContext,
@@ -58,7 +60,7 @@ func NewGrpcWorkflowRunner(
 }
 
 func (t *GrpcWorkflowRunner) Execute(workflowName commonworkflow.WorkflowName) error {
-	stream, err := t.buildStream(workflowName)
+	stream, err := t.buildStream()
 	if err != nil {
 		return err
 	}
@@ -69,6 +71,16 @@ func (t *GrpcWorkflowRunner) Execute(workflowName commonworkflow.WorkflowName) e
 			t.entrypointCtx.Logger.Error("Failed to close GRPC stream")
 		}
 	}(stream)
+
+	if err := stream.Send(&services.RunWorkflowStreamRequest{
+		Request: &services.RunWorkflowStreamRequest_RunRequest{
+			RunRequest: &services.WorkflowRunRequest{
+				WorkflowName: workflowName.String(),
+			},
+		},
+	}); err != nil {
+		return err
+	}
 
 	for {
 		instruction, err := stream.Recv()
@@ -90,11 +102,15 @@ func (t *GrpcWorkflowRunner) Execute(workflowName commonworkflow.WorkflowName) e
 					t.entrypointCtx.Logger.Info(fmt.Sprintf("%s\n", stdout))
 					t.entrypointCtx.Logger.Info(fmt.Sprintf("%s\n", stderr))
 
-					if err := stream.Send(&services.WorkflowStreamRequest{
-						Result: services.WorkflowResult_RUN_COMMAND_RESULT,
-						RunCommandResult: &services.WorkflowRunResult{
-							Stdout: stdout,
-							Stderr: stderr,
+					if err := stream.Send(&services.RunWorkflowStreamRequest{
+						Request: &services.RunWorkflowStreamRequest_StreamRequest{
+							StreamRequest: &services.WorkflowStreamRequest{
+								Result: services.WorkflowResult_RUN_COMMAND_RESULT,
+								RunCommandResult: &services.WorkflowRunResult{
+									Stdout: stdout,
+									Stderr: stderr,
+								},
+							},
 						},
 					}); err != nil {
 						return err
@@ -108,18 +124,25 @@ func (t *GrpcWorkflowRunner) Execute(workflowName commonworkflow.WorkflowName) e
 				return err
 			}
 
-			if err := stream.Send(&services.WorkflowStreamRequest{
-				Result: services.WorkflowResult_RUN_COMMAND_RESULT,
-				RunCommandResult: &services.WorkflowRunResult{
-					ExitCode: &exitCode,
+			if err := stream.Send(&services.RunWorkflowStreamRequest{
+				Request: &services.RunWorkflowStreamRequest_StreamRequest{
+					StreamRequest: &services.WorkflowStreamRequest{
+						Result: services.WorkflowResult_RUN_COMMAND_RESULT,
+						RunCommandResult: &services.WorkflowRunResult{
+							ExitCode: &exitCode,
+						},
+					},
 				},
 			}); err != nil {
 				return err
 			}
 
 		case services.WorkflowAction_COMPLETE_ACTION:
-			if workflowName == commonworkflow.FirstPreStart {
-				t.metadataState.Set(FirstPreStartCompleteMetadataKey, "true")
+			switch workflowName {
+			case commonworkflow.FirstPreStartContainer:
+				t.metadataState.Set(FirstPreStartContainerCompleteMetadataKey, "true")
+			case commonworkflow.FirstPostStartContainer:
+				t.metadataState.Set(FirstPostStartContainerCompleteMetadataKey, "true")
 			}
 
 		default:
@@ -138,23 +161,9 @@ func (t *GrpcWorkflowRunner) Close() error {
 	return t.conn.Close()
 }
 
-func (t *GrpcWorkflowRunner) buildStream(workflowName commonworkflow.WorkflowName) (WorkflowStream, error) {
+func (t *GrpcWorkflowRunner) buildStream() (WorkflowStream, error) {
 	ctx := metadata.NewOutgoingContext(context.Background(), t.metadataState.ExportToGrpcMetadata())
-
-	switch workflowName {
-	case commonworkflow.FirstPreStart:
-		return t.workflowClient.FirstPreStartWorkflowStream(ctx)
-	case commonworkflow.PreStart:
-		return t.workflowClient.PreStartWorkflowStream(ctx)
-	case commonworkflow.PostStart:
-		return t.workflowClient.PostStartWorkflowStream(ctx)
-	case commonworkflow.PreStop:
-		return t.workflowClient.PreStopWorkflowStream(ctx)
-	case commonworkflow.PreDestroy:
-		return t.workflowClient.PreDestroyWorkflowStream(ctx)
-	default:
-		return nil, errors.New("invalid wms name")
-	}
+	return t.workflowClient.RunWorkflowStream(ctx)
 }
 
 func (t *GrpcWorkflowRunner) execute(

--- a/internal/pkg/impl/host/grpc/interceptors/first_pre_post_start_container_complete.go
+++ b/internal/pkg/impl/host/grpc/interceptors/first_pre_post_start_container_complete.go
@@ -10,10 +10,13 @@ import (
 	container_types "github.com/spaulg/solo/internal/pkg/types/host/container"
 )
 
-const FirstPreStartCompleteMetadataKey = "first_pre_start_complete"
-const FirstPreStartCompleteContextValueName = "FirstPreStartComplete"
+const FirstPreStartContainerCompleteMetadataKey = "first_pre_start_container_complete"
+const FirstPostStartContainerCompleteMetadataKey = "first_post_start_container_complete"
+const FirstPreStartContainerCompleteContextValueName = "FirstPreStartComplete"
+const FirstPostStartContainerCompleteContextValueName = "FirstPostStartComplete"
 
 type FirstPreStartComplete string
+type FirstPostStartComplete string
 
 type FirstPreStartCompleteInterceptor struct {
 	orchestrator container_types.Orchestrator
@@ -36,9 +39,14 @@ func (t *FirstPreStartCompleteInterceptor) FirstPreStartCompleteUnaryInterceptor
 		return nil, fmt.Errorf("failed to load metadata from incoming context")
 	}
 
-	firstPreStartComplete := md.Get(FirstPreStartCompleteMetadataKey)
+	firstPreStartComplete := md.Get(FirstPreStartContainerCompleteMetadataKey)
 	if len(firstPreStartComplete) > 0 {
-		ctx = context.WithValue(ctx, FirstPreStartComplete(FirstPreStartCompleteContextValueName), firstPreStartComplete[0])
+		ctx = context.WithValue(ctx, FirstPreStartComplete(FirstPreStartContainerCompleteContextValueName), firstPreStartComplete[0])
+	}
+
+	firstPostStartComplete := md.Get(FirstPostStartContainerCompleteMetadataKey)
+	if len(firstPostStartComplete) > 0 {
+		ctx = context.WithValue(ctx, FirstPostStartComplete(FirstPostStartContainerCompleteContextValueName), firstPostStartComplete[0])
 	}
 
 	return handler(ctx, req)
@@ -56,9 +64,14 @@ func (t *FirstPreStartCompleteInterceptor) FirstPreStartCompleteStreamIntercepto
 		return fmt.Errorf("failed to load metadata from incoming context")
 	}
 
-	firstPreStartComplete := md.Get(FirstPreStartCompleteMetadataKey)
+	firstPreStartComplete := md.Get(FirstPreStartContainerCompleteMetadataKey)
 	if len(firstPreStartComplete) > 0 {
-		ctx = context.WithValue(ctx, FirstPreStartComplete(FirstPreStartCompleteContextValueName), firstPreStartComplete[0])
+		ctx = context.WithValue(ctx, FirstPreStartComplete(FirstPreStartContainerCompleteContextValueName), firstPreStartComplete[0])
+	}
+
+	firstPostStartComplete := md.Get(FirstPostStartContainerCompleteMetadataKey)
+	if len(firstPostStartComplete) > 0 {
+		ctx = context.WithValue(ctx, FirstPostStartComplete(FirstPostStartContainerCompleteContextValueName), firstPostStartComplete[0])
 	}
 
 	streamWrapper := NewServerStreamWrapper(ss, ctx)

--- a/internal/pkg/impl/host/grpc/interceptors/first_pre_post_start_container_complete_test.go
+++ b/internal/pkg/impl/host/grpc/interceptors/first_pre_post_start_container_complete_test.go
@@ -29,7 +29,7 @@ func (t *FirstPreStartCompleteTestSuite) SetupTest() {
 func (t *FirstPreStartCompleteTestSuite) TestSuccessfulFirstPreStartCompleteUnaryInterceptor() {
 	expectedFirstPreStartComplete := "true"
 	md := metadata.MD{}
-	md.Set(FirstPreStartCompleteMetadataKey, expectedFirstPreStartComplete)
+	md.Set(FirstPreStartContainerCompleteMetadataKey, expectedFirstPreStartComplete)
 	ctx := metadata.NewIncomingContext(context.Background(), md)
 
 	info := &grpc.UnaryServerInfo{}
@@ -38,7 +38,7 @@ func (t *FirstPreStartCompleteTestSuite) TestSuccessfulFirstPreStartCompleteUnar
 
 	interceptor := NewFirstPreStartCompleteInterceptor(t.mockOrchestrator)
 	result, err := interceptor.FirstPreStartCompleteUnaryInterceptor(ctx, req, info, func(ctx context.Context, req any) (any, error) {
-		firstPreStartComplete, ok := ctx.Value(FirstPreStartComplete(FirstPreStartCompleteContextValueName)).(string)
+		firstPreStartComplete, ok := ctx.Value(FirstPreStartComplete(FirstPreStartContainerCompleteContextValueName)).(string)
 
 		t.True(ok)
 		t.Equal(expectedFirstPreStartComplete, firstPreStartComplete)
@@ -70,7 +70,7 @@ func (t *FirstPreStartCompleteTestSuite) TestFirstPreStartCompleteUnaryIntercept
 func (t *FirstPreStartCompleteTestSuite) TestSuccessfulFirstPreStartCompleteStreamInterceptor() {
 	expectedFirstPreStartComplete := "true"
 	md := metadata.MD{}
-	md.Set(FirstPreStartCompleteMetadataKey, expectedFirstPreStartComplete)
+	md.Set(FirstPreStartContainerCompleteMetadataKey, expectedFirstPreStartComplete)
 	ctx := metadata.NewIncomingContext(context.Background(), md)
 
 	info := &grpc.StreamServerInfo{}
@@ -81,7 +81,7 @@ func (t *FirstPreStartCompleteTestSuite) TestSuccessfulFirstPreStartCompleteStre
 
 	interceptor := NewFirstPreStartCompleteInterceptor(t.mockOrchestrator)
 	err := interceptor.FirstPreStartCompleteStreamInterceptor(srv, ss, info, func(srv any, stream grpc.ServerStream) error {
-		firstPreStartComplete, ok := stream.Context().Value(FirstPreStartComplete(FirstPreStartCompleteContextValueName)).(string)
+		firstPreStartComplete, ok := stream.Context().Value(FirstPreStartComplete(FirstPreStartContainerCompleteContextValueName)).(string)
 
 		t.True(ok)
 		t.Equal(expectedFirstPreStartComplete, firstPreStartComplete)

--- a/internal/pkg/impl/host/grpc/service_definitions/run_workflow_stream_wrapper.go
+++ b/internal/pkg/impl/host/grpc/service_definitions/run_workflow_stream_wrapper.go
@@ -1,0 +1,65 @@
+package service_definitions
+
+import (
+	"context"
+	"errors"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+
+	"github.com/spaulg/solo/internal/pkg/impl/common/grpc/services"
+)
+
+type RunWorkflowStreamWrapper struct {
+	server grpc.BidiStreamingServer[services.RunWorkflowStreamRequest, services.WorkflowStreamResponse]
+}
+
+func NewRunWorkflowStreamWrapper(
+	server grpc.BidiStreamingServer[services.RunWorkflowStreamRequest, services.WorkflowStreamResponse],
+) RunWorkflowStreamWrapper {
+	return RunWorkflowStreamWrapper{
+		server: server,
+	}
+}
+
+func (t RunWorkflowStreamWrapper) Recv() (*services.WorkflowStreamRequest, error) {
+	req, err := t.server.Recv()
+	if err != nil {
+		return nil, err
+	}
+
+	switch subRequest := (req.Request).(type) {
+	case *services.RunWorkflowStreamRequest_StreamRequest:
+		return subRequest.StreamRequest, nil
+	default:
+		return nil, errors.New("not a stream request")
+	}
+}
+
+func (t RunWorkflowStreamWrapper) Send(response *services.WorkflowStreamResponse) error {
+	return t.server.Send(response)
+}
+
+func (t RunWorkflowStreamWrapper) SetHeader(md metadata.MD) error {
+	return t.server.SetHeader(md)
+}
+
+func (t RunWorkflowStreamWrapper) SendHeader(md metadata.MD) error {
+	return t.server.SendHeader(md)
+}
+
+func (t RunWorkflowStreamWrapper) SetTrailer(md metadata.MD) {
+	t.server.SetTrailer(md)
+}
+
+func (t RunWorkflowStreamWrapper) Context() context.Context {
+	return t.server.Context()
+}
+
+func (t RunWorkflowStreamWrapper) SendMsg(m any) error {
+	return t.server.SendMsg(m)
+}
+
+func (t RunWorkflowStreamWrapper) RecvMsg(m any) error {
+	return t.server.RecvMsg(m)
+}

--- a/internal/pkg/impl/host/grpc/service_definitions/workflow.go
+++ b/internal/pkg/impl/host/grpc/service_definitions/workflow.go
@@ -37,34 +37,21 @@ func NewWorkflowService(
 	}
 }
 
-func (t WorkflowServerImpl) FirstPreStartWorkflowStream(
-	server grpc.BidiStreamingServer[services.WorkflowStreamRequest, services.WorkflowStreamResponse],
+func (t WorkflowServerImpl) RunWorkflowStream(
+	server grpc.BidiStreamingServer[services.RunWorkflowStreamRequest, services.WorkflowStreamResponse],
 ) error {
-	return t.workflowStream(commonworkflow.FirstPreStart, server)
-}
+	message, err := server.Recv()
+	if err != nil {
+		return err
+	}
 
-func (t WorkflowServerImpl) PreStartWorkflowStream(
-	server grpc.BidiStreamingServer[services.WorkflowStreamRequest, services.WorkflowStreamResponse],
-) error {
-	return t.workflowStream(commonworkflow.PreStart, server)
-}
-
-func (t WorkflowServerImpl) PostStartWorkflowStream(
-	server grpc.BidiStreamingServer[services.WorkflowStreamRequest, services.WorkflowStreamResponse],
-) error {
-	return t.workflowStream(commonworkflow.PostStart, server)
-}
-
-func (t WorkflowServerImpl) PreStopWorkflowStream(
-	server grpc.BidiStreamingServer[services.WorkflowStreamRequest, services.WorkflowStreamResponse],
-) error {
-	return t.workflowStream(commonworkflow.PreStop, server)
-}
-
-func (t WorkflowServerImpl) PreDestroyWorkflowStream(
-	server grpc.BidiStreamingServer[services.WorkflowStreamRequest, services.WorkflowStreamResponse],
-) error {
-	return t.workflowStream(commonworkflow.PreDestroy, server)
+	switch request := message.Request.(type) {
+	case *services.RunWorkflowStreamRequest_RunRequest:
+		bidiStreamServer := NewRunWorkflowStreamWrapper(server)
+		return t.workflowStream(commonworkflow.WorkflowNameFromString(request.RunRequest.WorkflowName), bidiStreamServer)
+	default:
+		return errors.New("unsupported first message")
+	}
 }
 
 func (t WorkflowServerImpl) workflowStream(
@@ -87,10 +74,15 @@ func (t WorkflowServerImpl) workflowStream(
 	}
 
 	// First pre start complete
-	firstPreStartCompleteContextValueName := interceptors.FirstPreStartComplete(interceptors.FirstPreStartCompleteContextValueName)
-	firstPreStartComplete, ok := server.Context().Value(firstPreStartCompleteContextValueName).(string)
+	firstPreStartCompleteContextValueName := interceptors.FirstPreStartComplete(interceptors.FirstPreStartContainerCompleteContextValueName)
+	firstPreStartComplete, firstPreStartok := server.Context().Value(firstPreStartCompleteContextValueName).(string)
 
-	if workflowName == commonworkflow.FirstPreStart && (ok || firstPreStartComplete == "true") {
+	// First post start complete
+	firstPostStartCompleteContextValueName := interceptors.FirstPostStartComplete(interceptors.FirstPostStartContainerCompleteContextValueName)
+	firstPostStartComplete, firstPostStartok := server.Context().Value(firstPostStartCompleteContextValueName).(string)
+
+	if workflowName == commonworkflow.FirstPreStartContainer && (firstPreStartok || firstPreStartComplete == "true") ||
+		workflowName == commonworkflow.FirstPostStartContainer && (firstPostStartok || firstPostStartComplete == "true") {
 		t.eventManager.Publish(&wms_types.WorkflowSkippedEvent{
 			BaseWorkflowEvent: wms_types.BaseWorkflowEvent{
 				ServiceName:   serviceName,

--- a/internal/pkg/impl/host/grpc/service_definitions/workflow_test.go
+++ b/internal/pkg/impl/host/grpc/service_definitions/workflow_test.go
@@ -37,8 +37,8 @@ type WorkflowTestSuite struct {
 	mockEventManager         *events.MockEventManager
 	mockWorkflowOrchestrator *wms.MockOrchestrator
 	mockWorkflowFactory      *wms.MockWorkflowFactory
-	mockGrpcServer           *grpc.MockBidiStreamingServer[services.WorkflowStreamRequest, services.WorkflowStreamResponse]
 	mockOrchestrator         *container.MockOrchestrator
+	mockGrpcServer           *grpc.MockBidiStreamingServer[services.RunWorkflowStreamRequest, services.WorkflowStreamResponse]
 }
 
 func (t *WorkflowTestSuite) SetupTest() {
@@ -46,8 +46,8 @@ func (t *WorkflowTestSuite) SetupTest() {
 	t.mockWorkflowOrchestrator = &wms.MockOrchestrator{}
 	t.mockWorkflowFactory = &wms.MockWorkflowFactory{}
 	t.mockProject = &project.MockProject{}
-	t.mockGrpcServer = &grpc.MockBidiStreamingServer[services.WorkflowStreamRequest, services.WorkflowStreamResponse]{}
 	t.mockOrchestrator = &container.MockOrchestrator{}
+	t.mockGrpcServer = &grpc.MockBidiStreamingServer[services.RunWorkflowStreamRequest, services.WorkflowStreamResponse]{}
 
 	t.mockLogHandler = &logging.MockHandler{}
 	t.mockLogHandler.On("Enabled", mock.Anything, mock.Anything).Return(true)
@@ -77,8 +77,16 @@ func (t *WorkflowTestSuite) TestMissingServiceName() {
 		return record.Message == "Service name not found"
 	})).Return(nil)
 
+	t.mockGrpcServer.On("Recv").Return(&services.RunWorkflowStreamRequest{
+		Request: &services.RunWorkflowStreamRequest_RunRequest{
+			RunRequest: &services.WorkflowRunRequest{
+				WorkflowName: commonworkflow.FirstPreStartContainer.String(),
+			},
+		},
+	}, nil).Once()
+
 	workflowService := NewWorkflowService(t.soloCtx, t.mockEventManager, t.mockOrchestrator, t.mockWorkflowFactory)
-	err := workflowService.FirstPreStartWorkflowStream(t.mockGrpcServer)
+	err := workflowService.RunWorkflowStream(t.mockGrpcServer)
 
 	t.Error(err, "unauthorized")
 
@@ -97,12 +105,20 @@ func (t *WorkflowTestSuite) TestMissingContainerName() {
 
 	t.mockGrpcServer.On("Context").Return(ctx)
 
+	t.mockGrpcServer.On("Recv").Return(&services.RunWorkflowStreamRequest{
+		Request: &services.RunWorkflowStreamRequest_RunRequest{
+			RunRequest: &services.WorkflowRunRequest{
+				WorkflowName: commonworkflow.FirstPreStartContainer.String(),
+			},
+		},
+	}, nil).Once()
+
 	t.mockLogHandler.On("Handle", mock.Anything, mock.MatchedBy(func(record slog.Record) bool {
 		return record.Message == "Container name not found"
 	})).Return(nil)
 
 	workflowService := NewWorkflowService(t.soloCtx, t.mockEventManager, t.mockOrchestrator, t.mockWorkflowFactory)
-	err := workflowService.FirstPreStartWorkflowStream(t.mockGrpcServer)
+	err := workflowService.RunWorkflowStream(t.mockGrpcServer)
 
 	t.Error(err, "unauthorized")
 
@@ -127,17 +143,25 @@ func (t *WorkflowTestSuite) TestNilWorkflowFromFactory() {
 		BaseWorkflowEvent: wms_types.BaseWorkflowEvent{
 			ServiceName:   "test_service",
 			ContainerName: "test_service-1",
-			WorkflowName:  commonworkflow.PreStart,
+			WorkflowName:  commonworkflow.PreStartContainer,
 		},
 	}).Return()
 
 	t.mockWorkflowFactory.On("Make", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, nil)
 
+	t.mockGrpcServer.On("Recv").Return(&services.RunWorkflowStreamRequest{
+		Request: &services.RunWorkflowStreamRequest_RunRequest{
+			RunRequest: &services.WorkflowRunRequest{
+				WorkflowName: commonworkflow.PreStartContainer.String(),
+			},
+		},
+	}, nil).Once()
+
 	t.mockEventManager.On("Publish", &wms_types.WorkflowCompleteEvent{
 		BaseWorkflowEvent: wms_types.BaseWorkflowEvent{
 			ServiceName:   "test_service",
 			ContainerName: "test_service-1",
-			WorkflowName:  commonworkflow.PreStart,
+			WorkflowName:  commonworkflow.PreStartContainer,
 		},
 		Successful: true,
 	}).Return()
@@ -148,7 +172,7 @@ func (t *WorkflowTestSuite) TestNilWorkflowFromFactory() {
 	}).Return(nil)
 
 	workflowService := NewWorkflowService(t.soloCtx, t.mockEventManager, t.mockOrchestrator, t.mockWorkflowFactory)
-	_ = workflowService.PreStartWorkflowStream(t.mockGrpcServer)
+	_ = workflowService.RunWorkflowStream(t.mockGrpcServer)
 
 	t.mockEventManager.AssertExpectations(t.T())
 	t.mockWorkflowFactory.AssertExpectations(t.T())
@@ -159,7 +183,7 @@ func (t *WorkflowTestSuite) TestNilWorkflowFromFactory() {
 func (t *WorkflowTestSuite) TestFirstPreStartSkippedWorkflowStepTrigger() {
 	serviceNameContextValueName := interceptors.ServiceName(interceptors.ServiceNameContextValueName)
 	containerNameContextValueName := interceptors.ContainerName(interceptors.ContainerNameContextValueName)
-	firstPreStartCompleteContextValueName := interceptors.FirstPreStartComplete(interceptors.FirstPreStartCompleteContextValueName)
+	firstPreStartCompleteContextValueName := interceptors.FirstPreStartComplete(interceptors.FirstPreStartContainerCompleteContextValueName)
 
 	ctx := context.Background()
 	ctx = context.WithValue(ctx, serviceNameContextValueName, "test_service")
@@ -168,11 +192,19 @@ func (t *WorkflowTestSuite) TestFirstPreStartSkippedWorkflowStepTrigger() {
 
 	t.mockGrpcServer.On("Context").Return(ctx)
 
+	t.mockGrpcServer.On("Recv").Return(&services.RunWorkflowStreamRequest{
+		Request: &services.RunWorkflowStreamRequest_RunRequest{
+			RunRequest: &services.WorkflowRunRequest{
+				WorkflowName: commonworkflow.FirstPreStartContainer.String(),
+			},
+		},
+	}, nil).Once()
+
 	t.mockEventManager.On("Publish", &wms_types.WorkflowSkippedEvent{
 		BaseWorkflowEvent: wms_types.BaseWorkflowEvent{
 			ServiceName:   "test_service",
 			ContainerName: "test_service-1",
-			WorkflowName:  commonworkflow.FirstPreStart,
+			WorkflowName:  commonworkflow.FirstPreStartContainer,
 		},
 		Successful: true,
 	}).Return()
@@ -183,7 +215,7 @@ func (t *WorkflowTestSuite) TestFirstPreStartSkippedWorkflowStepTrigger() {
 	}).Return(nil)
 
 	workflowService := NewWorkflowService(t.soloCtx, t.mockEventManager, t.mockOrchestrator, t.mockWorkflowFactory)
-	_ = workflowService.FirstPreStartWorkflowStream(t.mockGrpcServer)
+	_ = workflowService.RunWorkflowStream(t.mockGrpcServer)
 
 	t.mockEventManager.AssertExpectations(t.T())
 	t.mockWorkflowFactory.AssertExpectations(t.T())
@@ -192,10 +224,10 @@ func (t *WorkflowTestSuite) TestFirstPreStartSkippedWorkflowStepTrigger() {
 }
 
 func (t *WorkflowTestSuite) TestFirstPreStartRecvError() {
-	t.testServerRecvErrorFor(commonworkflow.FirstPreStart)
+	t.testServerRecvErrorFor(commonworkflow.FirstPreStartContainer)
 
 	workflowService := NewWorkflowService(t.soloCtx, t.mockEventManager, t.mockOrchestrator, t.mockWorkflowFactory)
-	_ = workflowService.FirstPreStartWorkflowStream(t.mockGrpcServer)
+	_ = workflowService.RunWorkflowStream(t.mockGrpcServer)
 
 	t.mockEventManager.AssertExpectations(t.T())
 	t.mockWorkflowFactory.AssertExpectations(t.T())
@@ -204,10 +236,10 @@ func (t *WorkflowTestSuite) TestFirstPreStartRecvError() {
 }
 
 func (t *WorkflowTestSuite) TestPreStartRecvError() {
-	t.testServerRecvErrorFor(commonworkflow.PreStart)
+	t.testServerRecvErrorFor(commonworkflow.PreStartContainer)
 
 	workflowService := NewWorkflowService(t.soloCtx, t.mockEventManager, t.mockOrchestrator, t.mockWorkflowFactory)
-	_ = workflowService.PreStartWorkflowStream(t.mockGrpcServer)
+	_ = workflowService.RunWorkflowStream(t.mockGrpcServer)
 
 	t.mockEventManager.AssertExpectations(t.T())
 	t.mockWorkflowFactory.AssertExpectations(t.T())
@@ -216,10 +248,10 @@ func (t *WorkflowTestSuite) TestPreStartRecvError() {
 }
 
 func (t *WorkflowTestSuite) TestPostStartRecvError() {
-	t.testServerRecvErrorFor(commonworkflow.PostStart)
+	t.testServerRecvErrorFor(commonworkflow.PostStartContainer)
 
 	workflowService := NewWorkflowService(t.soloCtx, t.mockEventManager, t.mockOrchestrator, t.mockWorkflowFactory)
-	_ = workflowService.PostStartWorkflowStream(t.mockGrpcServer)
+	_ = workflowService.RunWorkflowStream(t.mockGrpcServer)
 
 	t.mockEventManager.AssertExpectations(t.T())
 	t.mockWorkflowFactory.AssertExpectations(t.T())
@@ -228,10 +260,10 @@ func (t *WorkflowTestSuite) TestPostStartRecvError() {
 }
 
 func (t *WorkflowTestSuite) TestPreStopRecvError() {
-	t.testServerRecvErrorFor(commonworkflow.PreStop)
+	t.testServerRecvErrorFor(commonworkflow.PreStopContainer)
 
 	workflowService := NewWorkflowService(t.soloCtx, t.mockEventManager, t.mockOrchestrator, t.mockWorkflowFactory)
-	_ = workflowService.PreStopWorkflowStream(t.mockGrpcServer)
+	_ = workflowService.RunWorkflowStream(t.mockGrpcServer)
 
 	t.mockEventManager.AssertExpectations(t.T())
 	t.mockWorkflowFactory.AssertExpectations(t.T())
@@ -240,10 +272,10 @@ func (t *WorkflowTestSuite) TestPreStopRecvError() {
 }
 
 func (t *WorkflowTestSuite) TestPreDestroyRecvError() {
-	t.testServerRecvErrorFor(commonworkflow.PreDestroy)
+	t.testServerRecvErrorFor(commonworkflow.PreDestroyContainer)
 
 	workflowService := NewWorkflowService(t.soloCtx, t.mockEventManager, t.mockOrchestrator, t.mockWorkflowFactory)
-	_ = workflowService.PreDestroyWorkflowStream(t.mockGrpcServer)
+	_ = workflowService.RunWorkflowStream(t.mockGrpcServer)
 
 	t.mockEventManager.AssertExpectations(t.T())
 	t.mockWorkflowFactory.AssertExpectations(t.T())
@@ -252,10 +284,10 @@ func (t *WorkflowTestSuite) TestPreDestroyRecvError() {
 }
 
 func (t *WorkflowTestSuite) TestFirstPreStartUnknownWorkflowResult() {
-	t.testUnknownWorkflowResult(commonworkflow.FirstPreStart)
+	t.testUnknownWorkflowResult(commonworkflow.FirstPreStartContainer)
 
 	workflowService := NewWorkflowService(t.soloCtx, t.mockEventManager, t.mockOrchestrator, t.mockWorkflowFactory)
-	_ = workflowService.FirstPreStartWorkflowStream(t.mockGrpcServer)
+	_ = workflowService.RunWorkflowStream(t.mockGrpcServer)
 
 	t.mockEventManager.AssertExpectations(t.T())
 	t.mockWorkflowFactory.AssertExpectations(t.T())
@@ -264,10 +296,10 @@ func (t *WorkflowTestSuite) TestFirstPreStartUnknownWorkflowResult() {
 }
 
 func (t *WorkflowTestSuite) TestPreStartUnknownWorkflowResult() {
-	t.testUnknownWorkflowResult(commonworkflow.PreStart)
+	t.testUnknownWorkflowResult(commonworkflow.PreStartContainer)
 
 	workflowService := NewWorkflowService(t.soloCtx, t.mockEventManager, t.mockOrchestrator, t.mockWorkflowFactory)
-	_ = workflowService.PreStartWorkflowStream(t.mockGrpcServer)
+	_ = workflowService.RunWorkflowStream(t.mockGrpcServer)
 
 	t.mockEventManager.AssertExpectations(t.T())
 	t.mockWorkflowFactory.AssertExpectations(t.T())
@@ -276,10 +308,10 @@ func (t *WorkflowTestSuite) TestPreStartUnknownWorkflowResult() {
 }
 
 func (t *WorkflowTestSuite) TestPostStartUnknownWorkflowResult() {
-	t.testUnknownWorkflowResult(commonworkflow.PostStart)
+	t.testUnknownWorkflowResult(commonworkflow.PostStartContainer)
 
 	workflowService := NewWorkflowService(t.soloCtx, t.mockEventManager, t.mockOrchestrator, t.mockWorkflowFactory)
-	_ = workflowService.PostStartWorkflowStream(t.mockGrpcServer)
+	_ = workflowService.RunWorkflowStream(t.mockGrpcServer)
 
 	t.mockEventManager.AssertExpectations(t.T())
 	t.mockWorkflowFactory.AssertExpectations(t.T())
@@ -288,10 +320,10 @@ func (t *WorkflowTestSuite) TestPostStartUnknownWorkflowResult() {
 }
 
 func (t *WorkflowTestSuite) TestPreStopUnknownWorkflowResult() {
-	t.testUnknownWorkflowResult(commonworkflow.PreStop)
+	t.testUnknownWorkflowResult(commonworkflow.PreStopContainer)
 
 	workflowService := NewWorkflowService(t.soloCtx, t.mockEventManager, t.mockOrchestrator, t.mockWorkflowFactory)
-	_ = workflowService.PreStopWorkflowStream(t.mockGrpcServer)
+	_ = workflowService.RunWorkflowStream(t.mockGrpcServer)
 
 	t.mockEventManager.AssertExpectations(t.T())
 	t.mockWorkflowFactory.AssertExpectations(t.T())
@@ -300,10 +332,10 @@ func (t *WorkflowTestSuite) TestPreStopUnknownWorkflowResult() {
 }
 
 func (t *WorkflowTestSuite) TestPreDestroyUnknownWorkflowResult() {
-	t.testUnknownWorkflowResult(commonworkflow.PreDestroy)
+	t.testUnknownWorkflowResult(commonworkflow.PreDestroyContainer)
 
 	workflowService := NewWorkflowService(t.soloCtx, t.mockEventManager, t.mockOrchestrator, t.mockWorkflowFactory)
-	_ = workflowService.PreDestroyWorkflowStream(t.mockGrpcServer)
+	_ = workflowService.RunWorkflowStream(t.mockGrpcServer)
 
 	t.mockEventManager.AssertExpectations(t.T())
 	t.mockWorkflowFactory.AssertExpectations(t.T())
@@ -312,10 +344,10 @@ func (t *WorkflowTestSuite) TestPreDestroyUnknownWorkflowResult() {
 }
 
 func (t *WorkflowTestSuite) TestFirstPreStartZeroWorkflowStepTrigger() {
-	t.testWorkflowExecFor(commonworkflow.FirstPreStart, 0)
+	t.testWorkflowExecFor(commonworkflow.FirstPreStartContainer, 0)
 
 	workflowService := NewWorkflowService(t.soloCtx, t.mockEventManager, t.mockOrchestrator, t.mockWorkflowFactory)
-	_ = workflowService.FirstPreStartWorkflowStream(t.mockGrpcServer)
+	_ = workflowService.RunWorkflowStream(t.mockGrpcServer)
 
 	t.mockEventManager.AssertExpectations(t.T())
 	t.mockWorkflowFactory.AssertExpectations(t.T())
@@ -324,10 +356,10 @@ func (t *WorkflowTestSuite) TestFirstPreStartZeroWorkflowStepTrigger() {
 }
 
 func (t *WorkflowTestSuite) TestPreStartZeroWorkflowStepTrigger() {
-	t.testWorkflowExecFor(commonworkflow.PreStart, 0)
+	t.testWorkflowExecFor(commonworkflow.PreStartContainer, 0)
 
 	workflowService := NewWorkflowService(t.soloCtx, t.mockEventManager, t.mockOrchestrator, t.mockWorkflowFactory)
-	_ = workflowService.PreStartWorkflowStream(t.mockGrpcServer)
+	_ = workflowService.RunWorkflowStream(t.mockGrpcServer)
 
 	t.mockEventManager.AssertExpectations(t.T())
 	t.mockWorkflowFactory.AssertExpectations(t.T())
@@ -336,10 +368,10 @@ func (t *WorkflowTestSuite) TestPreStartZeroWorkflowStepTrigger() {
 }
 
 func (t *WorkflowTestSuite) TestPostStartZeroWorkflowStepTrigger() {
-	t.testWorkflowExecFor(commonworkflow.PostStart, 0)
+	t.testWorkflowExecFor(commonworkflow.PostStartContainer, 0)
 
 	workflowService := NewWorkflowService(t.soloCtx, t.mockEventManager, t.mockOrchestrator, t.mockWorkflowFactory)
-	_ = workflowService.PostStartWorkflowStream(t.mockGrpcServer)
+	_ = workflowService.RunWorkflowStream(t.mockGrpcServer)
 
 	t.mockEventManager.AssertExpectations(t.T())
 	t.mockWorkflowFactory.AssertExpectations(t.T())
@@ -348,10 +380,10 @@ func (t *WorkflowTestSuite) TestPostStartZeroWorkflowStepTrigger() {
 }
 
 func (t *WorkflowTestSuite) TestPreStopZeroWorkflowStepTrigger() {
-	t.testWorkflowExecFor(commonworkflow.PreStop, 0)
+	t.testWorkflowExecFor(commonworkflow.PreStopContainer, 0)
 
 	workflowService := NewWorkflowService(t.soloCtx, t.mockEventManager, t.mockOrchestrator, t.mockWorkflowFactory)
-	_ = workflowService.PreStopWorkflowStream(t.mockGrpcServer)
+	_ = workflowService.RunWorkflowStream(t.mockGrpcServer)
 
 	t.mockEventManager.AssertExpectations(t.T())
 	t.mockWorkflowFactory.AssertExpectations(t.T())
@@ -360,10 +392,10 @@ func (t *WorkflowTestSuite) TestPreStopZeroWorkflowStepTrigger() {
 }
 
 func (t *WorkflowTestSuite) TestPreDestroyZeroWorkflowStepTrigger() {
-	t.testWorkflowExecFor(commonworkflow.PreDestroy, 0)
+	t.testWorkflowExecFor(commonworkflow.PreDestroyContainer, 0)
 
 	workflowService := NewWorkflowService(t.soloCtx, t.mockEventManager, t.mockOrchestrator, t.mockWorkflowFactory)
-	_ = workflowService.PreDestroyWorkflowStream(t.mockGrpcServer)
+	_ = workflowService.RunWorkflowStream(t.mockGrpcServer)
 
 	t.mockEventManager.AssertExpectations(t.T())
 	t.mockWorkflowFactory.AssertExpectations(t.T())
@@ -372,10 +404,10 @@ func (t *WorkflowTestSuite) TestPreDestroyZeroWorkflowStepTrigger() {
 }
 
 func (t *WorkflowTestSuite) TestFirstPreStartNonZeroWorkflowStepTrigger() {
-	t.testWorkflowExecFor(commonworkflow.FirstPreStart, 10)
+	t.testWorkflowExecFor(commonworkflow.FirstPreStartContainer, 10)
 
 	workflowService := NewWorkflowService(t.soloCtx, t.mockEventManager, t.mockOrchestrator, t.mockWorkflowFactory)
-	_ = workflowService.FirstPreStartWorkflowStream(t.mockGrpcServer)
+	_ = workflowService.RunWorkflowStream(t.mockGrpcServer)
 
 	t.mockEventManager.AssertExpectations(t.T())
 	t.mockWorkflowFactory.AssertExpectations(t.T())
@@ -384,10 +416,10 @@ func (t *WorkflowTestSuite) TestFirstPreStartNonZeroWorkflowStepTrigger() {
 }
 
 func (t *WorkflowTestSuite) TestPreStartNonZeroWorkflowStepTrigger() {
-	t.testWorkflowExecFor(commonworkflow.PreStart, 10)
+	t.testWorkflowExecFor(commonworkflow.PreStartContainer, 10)
 
 	workflowService := NewWorkflowService(t.soloCtx, t.mockEventManager, t.mockOrchestrator, t.mockWorkflowFactory)
-	_ = workflowService.PreStartWorkflowStream(t.mockGrpcServer)
+	_ = workflowService.RunWorkflowStream(t.mockGrpcServer)
 
 	t.mockEventManager.AssertExpectations(t.T())
 	t.mockWorkflowFactory.AssertExpectations(t.T())
@@ -396,10 +428,10 @@ func (t *WorkflowTestSuite) TestPreStartNonZeroWorkflowStepTrigger() {
 }
 
 func (t *WorkflowTestSuite) TestPostStartNonZeroWorkflowStepTrigger() {
-	t.testWorkflowExecFor(commonworkflow.PostStart, 10)
+	t.testWorkflowExecFor(commonworkflow.PostStartContainer, 10)
 
 	workflowService := NewWorkflowService(t.soloCtx, t.mockEventManager, t.mockOrchestrator, t.mockWorkflowFactory)
-	_ = workflowService.PostStartWorkflowStream(t.mockGrpcServer)
+	_ = workflowService.RunWorkflowStream(t.mockGrpcServer)
 
 	t.mockEventManager.AssertExpectations(t.T())
 	t.mockWorkflowFactory.AssertExpectations(t.T())
@@ -408,10 +440,10 @@ func (t *WorkflowTestSuite) TestPostStartNonZeroWorkflowStepTrigger() {
 }
 
 func (t *WorkflowTestSuite) TestPreStopNonZeroWorkflowStepTrigger() {
-	t.testWorkflowExecFor(commonworkflow.PreStop, 10)
+	t.testWorkflowExecFor(commonworkflow.PreStopContainer, 10)
 
 	workflowService := NewWorkflowService(t.soloCtx, t.mockEventManager, t.mockOrchestrator, t.mockWorkflowFactory)
-	_ = workflowService.PreStopWorkflowStream(t.mockGrpcServer)
+	_ = workflowService.RunWorkflowStream(t.mockGrpcServer)
 
 	t.mockEventManager.AssertExpectations(t.T())
 	t.mockWorkflowFactory.AssertExpectations(t.T())
@@ -420,10 +452,10 @@ func (t *WorkflowTestSuite) TestPreStopNonZeroWorkflowStepTrigger() {
 }
 
 func (t *WorkflowTestSuite) TestPreDestroyNonZeroWorkflowStepTrigger() {
-	t.testWorkflowExecFor(commonworkflow.PreDestroy, 10)
+	t.testWorkflowExecFor(commonworkflow.PreDestroyContainer, 10)
 
 	workflowService := NewWorkflowService(t.soloCtx, t.mockEventManager, t.mockOrchestrator, t.mockWorkflowFactory)
-	_ = workflowService.PreDestroyWorkflowStream(t.mockGrpcServer)
+	_ = workflowService.RunWorkflowStream(t.mockGrpcServer)
 
 	t.mockEventManager.AssertExpectations(t.T())
 	t.mockWorkflowFactory.AssertExpectations(t.T())
@@ -450,6 +482,14 @@ func (t *WorkflowTestSuite) testWorkflowExecFor(workflow commonworkflow.Workflow
 	}).Return()
 
 	t.mockWorkflowFactory.On("Make", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(t.mockWorkflowOrchestrator, nil)
+
+	t.mockGrpcServer.On("Recv").Return(&services.RunWorkflowStreamRequest{
+		Request: &services.RunWorkflowStreamRequest_RunRequest{
+			RunRequest: &services.WorkflowRunRequest{
+				WorkflowName: workflow.String(),
+			},
+		},
+	}, nil).Once()
 
 	t.mockWorkflowOrchestrator.On("StepIterator").Return(func(yield func(wms_types.Step) bool) {
 		step := &wms.MockStep{}
@@ -493,12 +533,16 @@ func (t *WorkflowTestSuite) testWorkflowExecFor(workflow commonworkflow.Workflow
 			t.Nil(err)
 
 			// progress
-			t.mockGrpcServer.On("Recv").Return(&services.WorkflowStreamRequest{
-				Result: services.WorkflowResult_RUN_COMMAND_RESULT,
-				RunCommandResult: &services.WorkflowRunResult{
-					Stdout:   "Hello World",
-					Stderr:   "",
-					ExitCode: &exitCode,
+			t.mockGrpcServer.On("Recv").Return(&services.RunWorkflowStreamRequest{
+				Request: &services.RunWorkflowStreamRequest_StreamRequest{
+					StreamRequest: &services.WorkflowStreamRequest{
+						Result: services.WorkflowResult_RUN_COMMAND_RESULT,
+						RunCommandResult: &services.WorkflowRunResult{
+							Stdout:   "Hello World",
+							Stderr:   "",
+							ExitCode: &exitCode,
+						},
+					},
 				},
 			}, nil)
 
@@ -573,6 +617,14 @@ func (t *WorkflowTestSuite) testServerRecvErrorFor(workflow commonworkflow.Workf
 	}).Return()
 
 	t.mockWorkflowFactory.On("Make", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(t.mockWorkflowOrchestrator, nil)
+
+	t.mockGrpcServer.On("Recv").Return(&services.RunWorkflowStreamRequest{
+		Request: &services.RunWorkflowStreamRequest_RunRequest{
+			RunRequest: &services.WorkflowRunRequest{
+				WorkflowName: workflow.String(),
+			},
+		},
+	}, nil).Once()
 
 	t.mockWorkflowOrchestrator.On("StepIterator").Return(func(yield func(wms_types.Step) bool) {
 		step := &wms.MockStep{}
@@ -656,6 +708,14 @@ func (t *WorkflowTestSuite) testUnknownWorkflowResult(workflow commonworkflow.Wo
 
 	t.mockWorkflowFactory.On("Make", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(t.mockWorkflowOrchestrator, nil)
 
+	t.mockGrpcServer.On("Recv").Return(&services.RunWorkflowStreamRequest{
+		Request: &services.RunWorkflowStreamRequest_RunRequest{
+			RunRequest: &services.WorkflowRunRequest{
+				WorkflowName: workflow.String(),
+			},
+		},
+	}, nil).Once()
+
 	t.mockWorkflowOrchestrator.On("StepIterator").Return(func(yield func(wms_types.Step) bool) {
 		step := &wms.MockStep{}
 		step.On("GetId").Return("12345")
@@ -699,12 +759,16 @@ func (t *WorkflowTestSuite) testUnknownWorkflowResult(workflow commonworkflow.Wo
 
 			// progress
 			var exitCode uint32 = 0
-			t.mockGrpcServer.On("Recv").Return(&services.WorkflowStreamRequest{
-				Result: -9999,
-				RunCommandResult: &services.WorkflowRunResult{
-					Stdout:   "Hello World",
-					Stderr:   "",
-					ExitCode: &exitCode,
+			t.mockGrpcServer.On("Recv").Return(&services.RunWorkflowStreamRequest{
+				Request: &services.RunWorkflowStreamRequest_StreamRequest{
+					StreamRequest: &services.WorkflowStreamRequest{
+						Result: -9999,
+						RunCommandResult: &services.WorkflowRunResult{
+							Stdout:   "Hello World",
+							Stderr:   "",
+							ExitCode: &exitCode,
+						},
+					},
 				},
 			}, nil)
 

--- a/internal/pkg/impl/host/project_control.go
+++ b/internal/pkg/impl/host/project_control.go
@@ -95,9 +95,10 @@ func (t *ProjectControl) Start() error {
 	}
 
 	workflowNames := []workflowcommon.WorkflowName{
-		workflowcommon.FirstPreStart,
-		workflowcommon.PreStart,
-		workflowcommon.PostStart,
+		workflowcommon.FirstPreStartContainer,
+		workflowcommon.PreStartContainer,
+		workflowcommon.PostStartContainer,
+		workflowcommon.FirstPostStartContainer,
 	}
 
 	guard := t.workflowGuardFactory.Build(workflowNames, containerNames)
@@ -110,23 +111,34 @@ func (t *ProjectControl) Start() error {
 	}
 
 	if err := guard.Wait(func(container string, guardCallback func(name workflowcommon.WorkflowName) error) error {
-		if err := guardCallback(workflowcommon.FirstPreStart); err != nil {
+		if err := guardCallback(workflowcommon.FirstPreStartContainer); err != nil {
 			return err
 		}
 
-		if err := guardCallback(workflowcommon.PreStart); err != nil {
+		if err := guardCallback(workflowcommon.PreStartContainer); err != nil {
 			return err
 		}
 
 		// Exec post start commands
-		postStartCommand := []string{t.soloCtx.Config.Entrypoint.ContainerEntrypointPath, "trigger-event", "post_start"}
-
-		if err := orchestrator.StartCommand(container, postStartCommand); err != nil {
-			return fmt.Errorf("error running compose: %w", err)
+		postStartEvents := []workflowcommon.WorkflowName{
+			workflowcommon.PostStartContainer,
+			workflowcommon.FirstPostStartContainer,
 		}
 
-		if err := guardCallback(workflowcommon.PostStart); err != nil {
-			return err
+		for _, event := range postStartEvents {
+			postStartCommand := []string{
+				t.soloCtx.Config.Entrypoint.ContainerEntrypointPath,
+				"trigger-event",
+				event.String(),
+			}
+
+			if err := orchestrator.StartCommand(container, postStartCommand); err != nil {
+				return fmt.Errorf("error running compose: %w", err)
+			}
+
+			if err := guardCallback(event); err != nil {
+				return err
+			}
 		}
 
 		return nil
@@ -185,7 +197,7 @@ func (t *ProjectControl) Stop() error {
 		}
 
 		workflowNames := []workflowcommon.WorkflowName{
-			workflowcommon.PreStop,
+			workflowcommon.PreStopContainer,
 		}
 
 		guard := t.workflowGuardFactory.Build(workflowNames, containerNames)
@@ -194,7 +206,11 @@ func (t *ProjectControl) Stop() error {
 
 		if err := guard.Wait(func(container string, guardCallback func(name workflowcommon.WorkflowName) error) error {
 			// Exec pre stop commands
-			preStopCommand := []string{t.soloCtx.Config.Entrypoint.ContainerEntrypointPath, "trigger-event", "pre_stop"}
+			preStopCommand := []string{
+				t.soloCtx.Config.Entrypoint.ContainerEntrypointPath,
+				"trigger-event",
+				workflowcommon.PreStopContainer.String(),
+			}
 
 			if err := orchestrator.StartCommand(container, preStopCommand); err != nil {
 				return fmt.Errorf("error running compose: %w", err)
@@ -259,7 +275,7 @@ func (t *ProjectControl) Destroy() error {
 		}
 
 		workflowNames := []workflowcommon.WorkflowName{
-			workflowcommon.PreDestroy,
+			workflowcommon.PreDestroyContainer,
 		}
 
 		guard := t.workflowGuardFactory.Build(workflowNames, containerNames)
@@ -268,7 +284,11 @@ func (t *ProjectControl) Destroy() error {
 
 		if err := guard.Wait(func(container string, guardCallback func(name workflowcommon.WorkflowName) error) error {
 			// Exec pre destroy commands
-			preDestroyCommand := []string{t.soloCtx.Config.Entrypoint.ContainerEntrypointPath, "trigger-event", "pre_destroy"}
+			preDestroyCommand := []string{
+				t.soloCtx.Config.Entrypoint.ContainerEntrypointPath,
+				"trigger-event",
+				workflowcommon.PreDestroyContainer.String(),
+			}
 
 			if err := orchestrator.StartCommand(container, preDestroyCommand); err != nil {
 				return fmt.Errorf("error running compose: %w", err)

--- a/internal/pkg/impl/host/wms/workflow_factory_test.go
+++ b/internal/pkg/impl/host/wms/workflow_factory_test.go
@@ -31,7 +31,7 @@ func (t *WorkflowFactoryTestSuite) SetupTest() {
 
 func (t *WorkflowFactoryTestSuite) TestBuild() {
 	serviceName := "test"
-	workflowName := workflowcommon.FirstPreStart
+	workflowName := workflowcommon.FirstPreStartContainer
 
 	workflowConfig := compose_types.ServiceWorkflowConfig{
 		Steps: make([]compose_types.WorkflowStep, 0),

--- a/internal/pkg/impl/host/wms/workflow_guard_factory_test.go
+++ b/internal/pkg/impl/host/wms/workflow_guard_factory_test.go
@@ -20,7 +20,7 @@ type WorkflowGuardFactoryTestSuite struct {
 func (t *WorkflowGuardFactoryTestSuite) TestBuild() {
 	soloCtx := &context.CliContext{}
 
-	workflowNames := []workflowcommon.WorkflowName{workflowcommon.FirstPreStart, workflowcommon.PreStart, workflowcommon.PostStart}
+	workflowNames := []workflowcommon.WorkflowName{workflowcommon.FirstPreStartContainer, workflowcommon.PreStartContainer, workflowcommon.PostStartContainer}
 	containerNames := []string{"container1", "container2"}
 
 	workflowGuardFactory := NewWorkflowGuardFactory(soloCtx)

--- a/internal/pkg/impl/host/wms/workflow_guard_test.go
+++ b/internal/pkg/impl/host/wms/workflow_guard_test.go
@@ -34,7 +34,7 @@ type WorkflowGuardTestSuite struct {
 
 func (t *WorkflowGuardTestSuite) SetupTest() {
 	t.mockProject = &project.MockProject{}
-	t.mockProject.On("GetMaxWorkflowTimeout", "first_pre_start").Return(30 * time.Second)
+	t.mockProject.On("GetMaxWorkflowTimeout", "first_pre_start_container").Return(30 * time.Second)
 
 	t.mockLogHandler = &logging.MockHandler{}
 	t.mockLogHandler.On("Enabled", context.Background(), mock.Anything).Return(true)
@@ -56,7 +56,7 @@ func (t *WorkflowGuardTestSuite) TestWorkflowCompleteOrSkippedEvents() {
 
 	guard := NewWorkflowGuard(
 		t.soloCtx,
-		[]workflowcommon.WorkflowName{workflowcommon.FirstPreStart},
+		[]workflowcommon.WorkflowName{workflowcommon.FirstPreStartContainer},
 		[]string{"container1", "container2"},
 	)
 
@@ -64,7 +64,7 @@ func (t *WorkflowGuardTestSuite) TestWorkflowCompleteOrSkippedEvents() {
 		BaseWorkflowEvent: wms_types.BaseWorkflowEvent{
 			ServiceName:   "test-service",
 			ContainerName: "container1",
-			WorkflowName:  workflowcommon.FirstPreStart,
+			WorkflowName:  workflowcommon.FirstPreStartContainer,
 		},
 		Successful: true,
 	})
@@ -73,13 +73,13 @@ func (t *WorkflowGuardTestSuite) TestWorkflowCompleteOrSkippedEvents() {
 		BaseWorkflowEvent: wms_types.BaseWorkflowEvent{
 			ServiceName:   "test-service",
 			ContainerName: "container2",
-			WorkflowName:  workflowcommon.FirstPreStart,
+			WorkflowName:  workflowcommon.FirstPreStartContainer,
 		},
 		Successful: true,
 	})
 
 	err := guard.Wait(func(container string, guardCallback func(name workflowcommon.WorkflowName) error) error {
-		return guardCallback(workflowcommon.FirstPreStart)
+		return guardCallback(workflowcommon.FirstPreStartContainer)
 	})
 
 	t.NoError(err)
@@ -93,7 +93,7 @@ func (t *WorkflowGuardTestSuite) TestWorkflowEventWithUnrecognisedEventType() {
 
 	guard := NewWorkflowGuard(
 		t.soloCtx,
-		[]workflowcommon.WorkflowName{workflowcommon.FirstPreStart},
+		[]workflowcommon.WorkflowName{workflowcommon.FirstPreStartContainer},
 		[]string{"container1"},
 	)
 
@@ -101,7 +101,7 @@ func (t *WorkflowGuardTestSuite) TestWorkflowEventWithUnrecognisedEventType() {
 		BaseWorkflowEvent: wms_types.BaseWorkflowEvent{
 			ServiceName:   "test-service",
 			ContainerName: "container1",
-			WorkflowName:  workflowcommon.PreStart,
+			WorkflowName:  workflowcommon.PreStartContainer,
 		},
 	})
 
@@ -110,16 +110,16 @@ func (t *WorkflowGuardTestSuite) TestWorkflowEventWithUnrecognisedEventType() {
 
 func (t *WorkflowGuardTestSuite) TestWorkflowEventWithUnrecognisedWorkflow() {
 	t.mockLogHandler.On("Handle", context.Background(), mock.MatchedBy(func(record slog.Record) bool {
-		return record.Message == "Received event completed for workflow pre_start for container container1"
+		return record.Message == "Received event completed for workflow pre_start_container for container container1"
 	})).Return(nil)
 
 	t.mockLogHandler.On("Handle", context.Background(), mock.MatchedBy(func(record slog.Record) bool {
-		return record.Message == "Workflow pre_start not registered for workflow guard"
+		return record.Message == "Workflow pre_start_container not registered for workflow guard"
 	})).Return(nil)
 
 	guard := NewWorkflowGuard(
 		t.soloCtx,
-		[]workflowcommon.WorkflowName{workflowcommon.FirstPreStart},
+		[]workflowcommon.WorkflowName{workflowcommon.FirstPreStartContainer},
 		[]string{"container1"},
 	)
 
@@ -127,7 +127,7 @@ func (t *WorkflowGuardTestSuite) TestWorkflowEventWithUnrecognisedWorkflow() {
 		BaseWorkflowEvent: wms_types.BaseWorkflowEvent{
 			ServiceName:   "test-service",
 			ContainerName: "container1",
-			WorkflowName:  workflowcommon.PreStart,
+			WorkflowName:  workflowcommon.PreStartContainer,
 		},
 		Successful: true,
 	})
@@ -137,7 +137,7 @@ func (t *WorkflowGuardTestSuite) TestWorkflowEventWithUnrecognisedWorkflow() {
 
 func (t *WorkflowGuardTestSuite) TestWorkflowEventWithUnrecognisedContainer() {
 	t.mockLogHandler.On("Handle", context.Background(), mock.MatchedBy(func(record slog.Record) bool {
-		return record.Message == "Received event completed for workflow first_pre_start for container container2"
+		return record.Message == "Received event completed for workflow first_pre_start_container for container container2"
 	})).Return(nil)
 
 	t.mockLogHandler.On("Handle", context.Background(), mock.MatchedBy(func(record slog.Record) bool {
@@ -146,7 +146,7 @@ func (t *WorkflowGuardTestSuite) TestWorkflowEventWithUnrecognisedContainer() {
 
 	guard := NewWorkflowGuard(
 		t.soloCtx,
-		[]workflowcommon.WorkflowName{workflowcommon.FirstPreStart},
+		[]workflowcommon.WorkflowName{workflowcommon.FirstPreStartContainer},
 		[]string{"container1"},
 	)
 
@@ -154,7 +154,7 @@ func (t *WorkflowGuardTestSuite) TestWorkflowEventWithUnrecognisedContainer() {
 		BaseWorkflowEvent: wms_types.BaseWorkflowEvent{
 			ServiceName:   "test-service",
 			ContainerName: "container2",
-			WorkflowName:  workflowcommon.FirstPreStart,
+			WorkflowName:  workflowcommon.FirstPreStartContainer,
 		},
 		Successful: true,
 	})
@@ -164,27 +164,27 @@ func (t *WorkflowGuardTestSuite) TestWorkflowEventWithUnrecognisedContainer() {
 
 func (t *WorkflowGuardTestSuite) TestWaitWithUnrecognisedWorkflow() {
 	t.mockLogHandler.On("Handle", context.Background(), mock.MatchedBy(func(record slog.Record) bool {
-		return record.Message == "Cannot wait for workflow pre_start to complete as this is not mapped"
+		return record.Message == "Cannot wait for workflow pre_start_container to complete as this is not mapped"
 	})).Return(nil)
 
 	t.mockLogHandler.On("Handle", context.Background(), mock.MatchedBy(func(record slog.Record) bool {
-		return record.Message == "Error waiting for container container1: unrecognised workflow pre_start"
+		return record.Message == "Error waiting for container container1: unrecognised workflow pre_start_container"
 	})).Return(nil)
 
 	t.mockLogHandler.On("Handle", context.Background(), mock.MatchedBy(func(record slog.Record) bool {
-		return record.Message == "Encountered 1 errors while waiting for containers: [unrecognised workflow pre_start]"
+		return record.Message == "Encountered 1 errors while waiting for containers: [unrecognised workflow pre_start_container]"
 	})).Return(nil)
 
 	guard := NewWorkflowGuard(
 		t.soloCtx,
-		[]workflowcommon.WorkflowName{workflowcommon.FirstPreStart},
+		[]workflowcommon.WorkflowName{workflowcommon.FirstPreStartContainer},
 		[]string{"container1"},
 	)
 
 	err := guard.Wait(func(container string, guardCallback func(name workflowcommon.WorkflowName) error) error {
-		return guardCallback(workflowcommon.PreStart)
+		return guardCallback(workflowcommon.PreStartContainer)
 	})
 
 	t.ErrorContains(err, "encountered errors while waiting for containers")
-	t.ErrorContains(err, "[unrecognised workflow pre_start]")
+	t.ErrorContains(err, "[unrecognised workflow pre_start_container]")
 }

--- a/solo.yml
+++ b/solo.yml
@@ -30,7 +30,7 @@ services:
       - "./go.sum:/solo/go.sum"
 
     x-workflows:
-      first_pre_start:
+      first_pre_start_container:
         timeout: 180s
 
         steps:
@@ -59,7 +59,7 @@ services:
       replicas: 3
 
     x-workflows:
-      first_pre_start:
+      first_pre_start_container:
         timeout: 180s
 
         steps:


### PR DESCRIPTION
Refactor GRPC workflow service to use a single rpc method and rename workflow names to suffix with Container.