### PR TITLE
Reload project file during rebuild to prevent corruption

### DIFF
--- a/internal/pkg/impl/host/events/manager.go
+++ b/internal/pkg/impl/host/events/manager.go
@@ -63,10 +63,7 @@ func (t *Manager) Publish(event events_types.Event) {
 
 	for _, ch := range t.subscribers {
 		t.wg.Add(1)
-
-		go func(ch chan events_types.Event) {
-			ch <- event
-		}(ch)
+		ch <- event
 	}
 }
 

--- a/internal/pkg/impl/host/project_control.go
+++ b/internal/pkg/impl/host/project_control.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spaulg/solo/internal/pkg/impl/common/cmd"
 	workflowcommon "github.com/spaulg/solo/internal/pkg/impl/common/wms"
 	"github.com/spaulg/solo/internal/pkg/impl/host/context"
+	"github.com/spaulg/solo/internal/pkg/impl/host/project"
 	"github.com/spaulg/solo/internal/pkg/impl/host/wms"
 	container_types "github.com/spaulg/solo/internal/pkg/types/host/container"
 	events_types "github.com/spaulg/solo/internal/pkg/types/host/events"
@@ -574,9 +575,14 @@ func (t *ProjectControl) internalRebuild() error {
 		return err
 	}
 
-	if err := t.soloCtx.Project.ReloadWithProfiles(profiles); err != nil {
+	// Re-scan for the project file and reload to prevent compounding
+	// config decoration on the same compose file when starting
+	reloadedProject, err := project.FindProject(t.soloCtx.Project.GetDirectory(), t.soloCtx.Config, profiles)
+	if err != nil {
 		return err
 	}
+
+	t.soloCtx.Project = reloadedProject
 
 	return t.internalStart()
 }

--- a/internal/pkg/impl/host/wms/workflow_guard.go
+++ b/internal/pkg/impl/host/wms/workflow_guard.go
@@ -16,6 +16,7 @@ import (
 
 type WorkflowGuard struct {
 	soloCtx                   *context.CliContext
+	channelLock               sync.Mutex
 	containers                []string
 	workflowContainerChannels map[workflowcommon.WorkflowName]map[string]chan int
 	workflowContainerStatus   map[workflowcommon.WorkflowName]map[string]bool
@@ -41,6 +42,7 @@ func NewWorkflowGuard(
 
 	return &WorkflowGuard{
 		soloCtx:                   soloCtx,
+		channelLock:               sync.Mutex{},
 		containers:                containers,
 		workflowContainerChannels: workflowContainerChannels,
 		workflowContainerStatus:   workflowContainerStatus,
@@ -74,6 +76,9 @@ func (t *WorkflowGuard) Publish(event events_types.Event) {
 		t.soloCtx.Logger.Warn(fmt.Sprintf("Workflow %s not registered for workflow guard", workflowName))
 		return
 	}
+
+	t.channelLock.Lock()
+	defer t.channelLock.Unlock()
 
 	if _, ok := t.workflowContainerChannels[workflowName][containerName]; !ok {
 		t.soloCtx.Logger.Warn(fmt.Sprintf("Container %s not registered for workflow guard or channel already closed", containerName))


### PR DESCRIPTION
Reload the project file during rebuild to prevent corrupting the state compose file version by double enhancing with changes from solo