### PR TITLE
Upgrade GH workflow to use Ubuntu 24.04 and latest action releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,16 +19,17 @@ permissions:
 jobs:
   build:
     name: 'Build'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
-      - uses: actions/setup-go@v5
+      - name: Install Go
+        uses: actions/setup-go@v6
         with:
-          go-version: stable
+          go-version-file: 'go.mod'
 
       - name: Update packages
         run: sudo apt update
@@ -38,8 +39,8 @@ jobs:
 
       - name: Install GRPC/protobuf compiler plugins
         run: |
-          go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
-          go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
+          go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.36.11
+          go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.5.1
 
       - name: Build
         run: make build
@@ -48,4 +49,4 @@ jobs:
         run: make test
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v8
+        uses: golangci/golangci-lint-action@v9


### PR DESCRIPTION
Upgrade GH workflow to use Ubuntu 24.04 and latest action releases