### PR TITLE
Fix issue where solo restart activates all profiles

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,3 +55,5 @@ jobs:
 
       - name: Lint
         uses: golangci/golangci-lint-action@v9
+        with:
+          version: v2.10.1

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Install protoc (see https://protobuf.dev/installation/)
 ```shell
 go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
 go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
-go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
+go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.10.1
 export PATH="$PATH:$HOME/go/bin"
 ```
 

--- a/cmd/solo/subcommand/destroy.go
+++ b/cmd/solo/subcommand/destroy.go
@@ -53,15 +53,7 @@ func NewDestroySubCommand(soloCtx *context.CliContext) *cobra.Command {
 				return err
 			}
 
-			if err := projectControl.Destroy(); err != nil {
-				return err
-			}
-
-			if len(profiles) == 1 && profiles[0] == "*" {
-				return projectControl.Clean(false)
-			}
-
-			return nil
+			return projectControl.Destroy()
 		}),
 	}
 

--- a/cmd/solo/subcommand/restart.go
+++ b/cmd/solo/subcommand/restart.go
@@ -32,7 +32,7 @@ func NewRestartCommand(soloCtx *context.CliContext) *cobra.Command {
 		}),
 	}
 
-	restartCmd.Flags().StringSliceVarP(&profiles, "profile", "", []string{"*"}, "Profiles to use for the command.")
+	restartCmd.Flags().StringSliceVarP(&profiles, "profile", "", nil, "Profiles to use for the command.")
 
 	return restartCmd
 }

--- a/cmd/solo/subcommand/stop.go
+++ b/cmd/solo/subcommand/stop.go
@@ -32,7 +32,7 @@ func NewStopCommand(soloCtx *context.CliContext) *cobra.Command {
 		}),
 	}
 
-	stopCmd.Flags().StringSliceVarP(&profiles, "profile", "", []string{"*"}, "Profiles to use for the command.")
+	stopCmd.Flags().StringSliceVarP(&profiles, "profile", "", nil, "Profiles to use for the command.")
 
 	return stopCmd
 }

--- a/internal/pkg/impl/entrypoint/shells/list_shells.go
+++ b/internal/pkg/impl/entrypoint/shells/list_shells.go
@@ -26,6 +26,7 @@ func ListShellsAsJSON(shellsFilePath string) (string, error) {
 			continue // skip empty lines and comment lines
 		}
 
+		// nolint:gosec
 		info, err := os.Stat(line)
 		if err != nil {
 			continue // skip missing files

--- a/internal/pkg/impl/host/project_control.go
+++ b/internal/pkg/impl/host/project_control.go
@@ -243,7 +243,7 @@ func (t *ProjectControl) internalStart() error {
 		t.soloCtx.Project = reloadedProject
 	}
 
-	serviceStatus, err := orchestrator.ServicesStatus(nil)
+	serviceStatus, err := orchestrator.ServicesStatus(t.soloCtx.Project.Services().ServiceNames())
 	if err != nil {
 		return fmt.Errorf("failed to check service status: %w", err)
 	}
@@ -375,7 +375,7 @@ func (t *ProjectControl) internalStop() error {
 	}
 
 	// Build workflow service map
-	serviceStatus, err := orchestrator.ServicesStatus(nil)
+	serviceStatus, err := orchestrator.ServicesStatus(t.soloCtx.Project.Services().ServiceNames())
 	if err != nil {
 		return fmt.Errorf("failed to check service status: %w", err)
 	}
@@ -462,7 +462,7 @@ func (t *ProjectControl) internalDestroy() error {
 	}
 
 	// Build workflow service map
-	serviceStatus, err := orchestrator.ServicesStatus(nil)
+	serviceStatus, err := orchestrator.ServicesStatus(t.soloCtx.Project.Services().ServiceNames())
 	if err != nil {
 		return fmt.Errorf("failed to check service status: %w", err)
 	}


### PR DESCRIPTION
Fix issue where solo restart activates all profiles.

Also fix issue where start, stop and restart affect all services due to listing all services from the orchestrator.

Also fix issue where destroy triggers cleanup outside of ProjectControl.