### PR TITLE
Move interface declarations to the point of consumption

### DIFF
--- a/internal/pkg/impl/architecture_test.go
+++ b/internal/pkg/impl/architecture_test.go
@@ -124,7 +124,6 @@ func (t *ArchitectureTestSuite) TestLayerDependencies() {
 				Package: t.moduleName + "/internal/pkg/impl/entrypoint/app.**",
 				ShouldOnlyDependsOn: &archgo_config.Dependencies{
 					Internal: []string{
-						t.moduleName + "/internal/pkg/types/entrypoint.**",
 						t.moduleName + "/internal/pkg/impl/entrypoint.**",
 						t.moduleName + "/internal/pkg/impl/common.**",
 					},
@@ -136,7 +135,6 @@ func (t *ArchitectureTestSuite) TestLayerDependencies() {
 				Package: t.moduleName + "/internal/pkg/impl/entrypoint/infra.**",
 				ShouldOnlyDependsOn: &archgo_config.Dependencies{
 					Internal: []string{
-						t.moduleName + "/internal/pkg/types/entrypoint/infra.**",
 						t.moduleName + "/internal/pkg/impl/entrypoint/infra.**",
 						t.moduleName + "/internal/pkg/impl/common/infra.**",
 					},

--- a/internal/pkg/impl/entrypoint/app/workflow/credentials_builder.go
+++ b/internal/pkg/impl/entrypoint/app/workflow/credentials_builder.go
@@ -1,4 +1,4 @@
-package credentials
+package workflow
 
 import "google.golang.org/grpc/credentials"
 

--- a/internal/pkg/impl/entrypoint/app/workflow/grpc_workflow_runner.go
+++ b/internal/pkg/impl/entrypoint/app/workflow/grpc_workflow_runner.go
@@ -14,7 +14,6 @@ import (
 	commonworkflow "github.com/spaulg/solo/internal/pkg/impl/common/domain/wms"
 	"github.com/spaulg/solo/internal/pkg/impl/common/infra/grpc/services"
 	entrypointcontext "github.com/spaulg/solo/internal/pkg/impl/entrypoint/app/context"
-	grpc_credentials_types "github.com/spaulg/solo/internal/pkg/types/entrypoint/infra/grpc/credentials"
 )
 
 const FirstPreStartContainerCompleteMetadataKey = "first_pre_start_container_complete"
@@ -31,7 +30,7 @@ type WorkflowStream grpc.BidiStreamingClient[services.RunWorkflowStreamRequest, 
 
 func NewGrpcWorkflowRunner(
 	entrypointCtx *entrypointcontext.EntrypointContext,
-	credentialsBuilder grpc_credentials_types.Builder,
+	credentialsBuilder Builder,
 	workflowServerHost string,
 	metadataState *MetadataState,
 ) (*GrpcWorkflowRunner, error) {

--- a/internal/pkg/impl/entrypoint/app/workflow_runner.go
+++ b/internal/pkg/impl/entrypoint/app/workflow_runner.go
@@ -1,4 +1,4 @@
-package workflow
+package app
 
 import (
 	"io"

--- a/internal/pkg/impl/entrypoint/app/workflow_runner_factory.go
+++ b/internal/pkg/impl/entrypoint/app/workflow_runner_factory.go
@@ -11,7 +11,7 @@ import (
 
 const metadataStateFile = "/solo/container/data/metadata_state.yml"
 
-func WorkflowRunnerFactory(entrypointCtx *context.EntrypointContext) (*workflow.GrpcWorkflowRunner, error) {
+func WorkflowRunnerFactory(entrypointCtx *context.EntrypointContext) (WorkflowRunner, error) {
 	targetBytes, err := os.ReadFile("/solo/services_all/provisioner_host")
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Move interface declarations to the point of consumption and collapse types and impl packages.