### PR TITLE
Move auditor interface to point of consumption

### DIFF
--- a/internal/pkg/impl/host/app/audit/state_directory_auditor.go
+++ b/internal/pkg/impl/host/app/audit/state_directory_auditor.go
@@ -15,7 +15,7 @@ const auditLogsPath = "audit_logs"
 const executionEventFile = "event.json"
 const metaFileSuffix = ".meta.json"
 
-type Auditor struct {
+type StateDirectoryAuditor struct {
 	soloCtx                       *context.CliContext
 	mu                            sync.Mutex
 	outputDirectory               string
@@ -31,14 +31,14 @@ func NewAuditor(
 	workflowLogMetaRepository domain.WorkflowLogMetaRepository,
 	workflowStepLogMetaRepository domain.WorkflowStepLogMetaRepository,
 	logWriter domain.LogWriter,
-) *Auditor {
+) *StateDirectoryAuditor {
 	outputDirectory := path.Join(
 		soloCtx.Project.GetStateDirectoryRoot(),
 		auditLogsPath,
 		soloCtx.TriggerDateTime.Format("2006-01-02T15-04-05.999999999Z"),
 	)
 
-	return &Auditor{
+	return &StateDirectoryAuditor{
 		soloCtx:                       soloCtx,
 		outputDirectory:               outputDirectory,
 		executionEventRepository:      executionEventRepository,
@@ -48,7 +48,7 @@ func NewAuditor(
 	}
 }
 
-func (t *Auditor) RecordExecutionEvent(callback func() error) error {
+func (t *StateDirectoryAuditor) RecordExecutionEvent(callback func() error) error {
 	eventFile := path.Join(t.outputDirectory, executionEventFile)
 
 	workflowEvent := domain.NewExecutionEvent(t.soloCtx.CommandPath, t.soloCtx.CommandArgs)
@@ -66,7 +66,7 @@ func (t *Auditor) RecordExecutionEvent(callback func() error) error {
 	return res
 }
 
-func (t *Auditor) Publish(event events_types.Event) {
+func (t *StateDirectoryAuditor) Publish(event events_types.Event) {
 	switch e := event.(type) {
 	case *wms_types.WorkflowStepOutputEvent:
 		t.writeStepOutput(e)
@@ -76,7 +76,7 @@ func (t *Auditor) Publish(event events_types.Event) {
 	}
 }
 
-func (t *Auditor) writeStepOutput(e *wms_types.WorkflowStepOutputEvent) {
+func (t *StateDirectoryAuditor) writeStepOutput(e *wms_types.WorkflowStepOutputEvent) {
 	if e.Stderr == "" && e.Stdout == "" {
 		return
 	}
@@ -153,7 +153,7 @@ func (t *Auditor) writeStepOutput(e *wms_types.WorkflowStepOutputEvent) {
 	}
 }
 
-func (t *Auditor) writeStepResult(e *wms_types.WorkflowStepCompleteEvent) {
+func (t *StateDirectoryAuditor) writeStepResult(e *wms_types.WorkflowStepCompleteEvent) {
 	outputDirectory := path.Join(
 		t.outputDirectory,
 		e.WorkflowName.String(),

--- a/internal/pkg/impl/host/app/auditor.go
+++ b/internal/pkg/impl/host/app/auditor.go
@@ -1,4 +1,4 @@
-package audit
+package app
 
 import (
 	events_types "github.com/spaulg/solo/internal/pkg/types/host/app/events"

--- a/internal/pkg/impl/host/app/project_control.go
+++ b/internal/pkg/impl/host/app/project_control.go
@@ -11,7 +11,6 @@ import (
 	"github.com/spaulg/solo/internal/pkg/impl/host/app/context"
 	"github.com/spaulg/solo/internal/pkg/impl/host/app/project"
 	"github.com/spaulg/solo/internal/pkg/impl/host/app/wms"
-	"github.com/spaulg/solo/internal/pkg/types/host/app/audit"
 	events_types "github.com/spaulg/solo/internal/pkg/types/host/app/events"
 	wms_types "github.com/spaulg/solo/internal/pkg/types/host/app/wms"
 	container_types "github.com/spaulg/solo/internal/pkg/types/host/infra/container"
@@ -26,7 +25,7 @@ type ProjectControl struct {
 	orchestratorFactory  container_types.OrchestratorFactory
 	grpcServerFactory    grpc_types.ServerFactory
 	workflowGuardFactory wms_types.WorkflowGuardFactory
-	auditor              audit.Auditor
+	auditor              Auditor
 }
 
 func NewProjectControl(
@@ -35,7 +34,7 @@ func NewProjectControl(
 	orchestratorFactory container_types.OrchestratorFactory,
 	grpcServerFactory grpc_types.ServerFactory,
 	workflowGuardFactory wms_types.WorkflowGuardFactory,
-	auditor audit.Auditor,
+	auditor Auditor,
 ) *ProjectControl {
 	return &ProjectControl{
 		soloCtx:              soloCtx,


### PR DESCRIPTION
Move auditor interface to point of consumption. Also rename auditor implementation to match its design.