### PR TITLE
Remove GRPC service definition coupling on WMS event publication

### DIFF
--- a/examples/symfony-webapp/solo.yml
+++ b/examples/symfony-webapp/solo.yml
@@ -16,6 +16,7 @@ services:
       context: .
       dockerfile: ./Dockerfile.php
     command: /usr/sbin/php-fpm8.5 -FO
+    working_dir: /var/www/project
 
     volumes:
       - "composer:/root/.cache/composer"
@@ -57,11 +58,9 @@ services:
         
         steps:
           - name: Clear project cache
-            working_dir: /var/www/project
             run: rm -rf var/cache/*
 
           - name: composer install
-            working_dir: /var/www/project
             run: composer install
 
   mail:

--- a/internal/pkg/impl/host/app/project_control_factory.go
+++ b/internal/pkg/impl/host/app/project_control_factory.go
@@ -44,7 +44,7 @@ func ProjectControlFactory(soloCtx *context.CliContext) (*ProjectControl, error)
 	workflowFactory := wms.NewWorkflowFactory()
 	workflowRunner := wms.NewWorkflowRunner(soloCtx, eventManager, workflowFactory)
 
-	grpcServerFactory := grpc.NewMutualTLSServerFactory(soloCtx, eventManager, certificateAuthority, workflowRunner)
+	grpcServerFactory := grpc.NewMutualTLSServerFactory(soloCtx, certificateAuthority, workflowRunner)
 
 	workflowGuardFactory := wms.NewWorkflowGuardFactory(soloCtx)
 

--- a/internal/pkg/impl/host/app/wms/workflow_runner.go
+++ b/internal/pkg/impl/host/app/wms/workflow_runner.go
@@ -27,7 +27,47 @@ func NewWorkflowRunner(
 	}
 }
 
-func (t *WorkflowRunner) RunWorkflow(workflowSession wms_shared.WorkflowSession) (bool, error) {
+func (t *WorkflowRunner) RunWorkflow(workflowSession wms_shared.WorkflowSession) error {
+	// Handle previously run once-only workflows
+	hasServiceWorkflowRun, err := workflowSession.HasServiceWorkflowRun(workflowSession.GetServiceName())
+	if err != nil {
+		return fmt.Errorf("failed to check if service workflow has run: %w", err)
+	}
+
+	hasFirstContainerWorkflowRun := workflowSession.HasFirstContainerWorkflowRun()
+
+	if hasServiceWorkflowRun || hasFirstContainerWorkflowRun {
+		t.eventManager.Publish(&wms_types.WorkflowSkippedEvent{
+			BaseWorkflowEvent: wms_types.BaseWorkflowEvent{
+				ServiceName:       workflowSession.GetServiceName(),
+				ContainerName:     workflowSession.GetContainerName(),
+				FullContainerName: workflowSession.GetFullContainerName(),
+				WorkflowName:      workflowSession.GetWorkflowName(),
+			},
+			Successful: true,
+		})
+	} else {
+		workflowSuccess, err := t.handleRunWorkflow(workflowSession)
+
+		if err != nil {
+			return err
+		}
+
+		t.eventManager.Publish(&wms_types.WorkflowCompleteEvent{
+			BaseWorkflowEvent: wms_types.BaseWorkflowEvent{
+				ServiceName:       workflowSession.GetServiceName(),
+				ContainerName:     workflowSession.GetContainerName(),
+				FullContainerName: workflowSession.GetFullContainerName(),
+				WorkflowName:      workflowSession.GetWorkflowName(),
+			},
+			Successful: workflowSuccess,
+		})
+	}
+
+	return workflowSession.MarkCompletion()
+}
+
+func (t *WorkflowRunner) handleRunWorkflow(workflowSession wms_shared.WorkflowSession) (bool, error) {
 	workflowSuccess := true
 
 	t.eventManager.Publish(&wms_types.WorkflowStartedEvent{

--- a/internal/pkg/impl/host/app/wms/workflow_runner_test.go
+++ b/internal/pkg/impl/host/app/wms/workflow_runner_test.go
@@ -37,6 +37,10 @@ type WorkflowRunnerTestSuite struct {
 
 	mockWorkflowOrchestrator *wms.MockWorkflow
 	workflowSession          *service_definitions.MockWorkflowSession
+
+	hasServiceWorkflowRun        bool
+	hasServiceWorkflowRunError   error
+	hasFirstContainerWorkflowRun bool
 }
 
 func (t *WorkflowRunnerTestSuite) SetupTest() {
@@ -64,77 +68,36 @@ func (t *WorkflowRunnerTestSuite) SetupTest() {
 	}
 
 	NewWorkflowRunner(t.soloCtx, t.mockEventManager, t.mockWorkflowFactory)
+
+	t.hasServiceWorkflowRun = false
+	t.hasServiceWorkflowRunError = nil
+	t.hasFirstContainerWorkflowRun = false
 }
 
-//	func (t *WorkflowRunnerTestSuite) TestNilWorkflowFromFactory() {
-//		serviceNameContextValueName := interceptors.ServiceName(interceptors.ServiceNameContextValueName)
-//		containerNameContextValueName := interceptors.ContainerName(interceptors.ContainerNameContextValueName)
-//		fullContainerNameContextValueName := interceptors.ContainerName(interceptors.FullContainerNameContextValueName)
-//
-//		ctx := context.Background()
-//		ctx = context.WithValue(ctx, serviceNameContextValueName, "test_service")
-//		ctx = context.WithValue(ctx, containerNameContextValueName, "service-1")
-//		ctx = context.WithValue(ctx, fullContainerNameContextValueName, "test_service-1")
-//
-//		t.mockGrpcServer.On("Context").Return(ctx)
-//
-//		t.mockEventManager.On("Publish", &wms_types.WorkflowStartedEvent{
-//			BaseWorkflowEvent: wms_types.BaseWorkflowEvent{
-//				ServiceName:       "test_service",
-//				ContainerName:     "service-1",
-//				FullContainerName: "test_service-1",
-//				WorkflowName:      commonworkflow.PreStartContainer,
-//			},
-//		}).Return()
-//
-//		t.mockWorkflowFactory.On("Make", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, nil)
-//
-//		t.mockGrpcServer.On("Recv").Return(&services.RunWorkflowStreamRequest{
-//			Request: &services.RunWorkflowStreamRequest_RunRequest{
-//				RunRequest: &services.WorkflowRunRequest{
-//					WorkflowName: commonworkflow.PreStartContainer.String(),
-//				},
-//			},
-//		}, nil).Once()
-//
-//		t.mockEventManager.On("Publish", &wms_types.WorkflowCompleteEvent{
-//			BaseWorkflowEvent: wms_types.BaseWorkflowEvent{
-//				ServiceName:       "test_service",
-//				ContainerName:     "service-1",
-//				FullContainerName: "test_service-1",
-//				WorkflowName:      commonworkflow.PreStartContainer,
-//			},
-//			Successful: true,
-//		}).Return()
-//
-//		t.mockGrpcServer.On("Send", &services.WorkflowStreamResponse{
-//			Action:     services.WorkflowAction_COMPLETE_ACTION,
-//			RunCommand: nil,
-//		}).Return(nil)
-//
-//		workflowService := NewWorkflowService(
-//			t.soloCtx,
-//			t.mockEventManager,
-//			t.mockOrchestrator,
-//			t.mockWorkflowFactory,
-//			t.mockWorkflowExecTracker,
-//			t.mockWorkflowRunner,
-//		)
-//
-//		err := workflowService.RunWorkflowStream(t.mockGrpcServer)
-//		t.NoError(err)
-//
-//		t.mockEventManager.AssertExpectations(t.T())
-//		t.mockWorkflowFactory.AssertExpectations(t.T())
-//		t.mockWorkflowOrchestrator.AssertExpectations(t.T())
-//		t.mockGrpcServer.AssertExpectations(t.T())
-//	}
-
 func (t *WorkflowRunnerTestSuite) testWorkflowExecFor(workflow commonworkflow.WorkflowName, exitCode uint8) {
+	t.workflowSession.On("HasServiceWorkflowRun", "test_service").Return(t.hasServiceWorkflowRun, t.hasServiceWorkflowRunError)
+	t.workflowSession.On("HasFirstContainerWorkflowRun").Return(t.hasFirstContainerWorkflowRun)
+	t.workflowSession.On("MarkCompletion").Return(nil)
+
 	t.workflowSession.On("GetServiceName").Return("test_service")
 	t.workflowSession.On("GetContainerName").Return("service-1")
 	t.workflowSession.On("GetFullContainerName").Return("test_service-1")
 	t.workflowSession.On("GetWorkflowName").Return(workflow)
+
+	if t.hasServiceWorkflowRun || t.hasFirstContainerWorkflowRun {
+		t.mockEventManager.On("Publish", &wms_types.WorkflowSkippedEvent{
+			BaseWorkflowEvent: wms_types.BaseWorkflowEvent{
+				ServiceName:       "test_service",
+				ContainerName:     "service-1",
+				FullContainerName: "test_service-1",
+				WorkflowName:      workflow,
+			},
+			Successful: true,
+		}).Return()
+
+		return
+	}
+
 	t.workflowSession.On("GetWorkingDirectory").Return("/", nil)
 
 	t.mockEventManager.On("Publish", &wms_types.WorkflowStartedEvent{
@@ -248,20 +211,59 @@ func (t *WorkflowRunnerTestSuite) testWorkflowExecFor(workflow commonworkflow.Wo
 		yield(step)
 	})
 
-	//t.mockEventManager.On("Publish", &wms_types.WorkflowCompleteEvent{
-	//	BaseWorkflowEvent: wms_types.BaseWorkflowEvent{
-	//		ServiceName:       "test_service",
-	//		ContainerName:     "service-1",
-	//		FullContainerName: "test_service-1",
-	//		WorkflowName:      workflow,
-	//	},
-	//	Successful: exitCode == 0,
-	//}).Return()
-	//
-	//t.mockGrpcServer.On("Send", &services.WorkflowStreamResponse{
-	//	Action:     services.WorkflowAction_COMPLETE_ACTION,
-	//	RunCommand: nil,
-	//}).Return(nil)
+	t.mockEventManager.On("Publish", &wms_types.WorkflowCompleteEvent{
+		BaseWorkflowEvent: wms_types.BaseWorkflowEvent{
+			ServiceName:       "test_service",
+			ContainerName:     "service-1",
+			FullContainerName: "test_service-1",
+			WorkflowName:      workflow,
+		},
+		Successful: exitCode == 0,
+	}).Return()
+}
+
+func (t *WorkflowRunnerTestSuite) TestServiceWorkflowRun() {
+	t.hasServiceWorkflowRun = true
+	t.hasServiceWorkflowRunError = nil
+	t.hasFirstContainerWorkflowRun = false
+
+	t.testWorkflowExecFor(commonworkflow.FirstPreStartContainer, 0)
+
+	workflowService := NewWorkflowRunner(
+		t.soloCtx,
+		t.mockEventManager,
+		t.mockWorkflowFactory,
+	)
+
+	err := workflowService.RunWorkflow(t.workflowSession)
+	t.NoError(err)
+
+	t.workflowSession.AssertExpectations(t.T())
+	t.mockEventManager.AssertExpectations(t.T())
+	t.mockWorkflowFactory.AssertExpectations(t.T())
+	t.mockWorkflowOrchestrator.AssertExpectations(t.T())
+}
+
+func (t *WorkflowRunnerTestSuite) TestContainerWorkflowRun() {
+	t.hasServiceWorkflowRun = false
+	t.hasServiceWorkflowRunError = nil
+	t.hasFirstContainerWorkflowRun = true
+
+	t.testWorkflowExecFor(commonworkflow.FirstPreStartContainer, 0)
+
+	workflowService := NewWorkflowRunner(
+		t.soloCtx,
+		t.mockEventManager,
+		t.mockWorkflowFactory,
+	)
+
+	err := workflowService.RunWorkflow(t.workflowSession)
+	t.NoError(err)
+
+	t.workflowSession.AssertExpectations(t.T())
+	t.mockEventManager.AssertExpectations(t.T())
+	t.mockWorkflowFactory.AssertExpectations(t.T())
+	t.mockWorkflowOrchestrator.AssertExpectations(t.T())
 }
 
 func (t *WorkflowRunnerTestSuite) TestFirstPreStartZeroWorkflowStepTrigger() {
@@ -273,8 +275,7 @@ func (t *WorkflowRunnerTestSuite) TestFirstPreStartZeroWorkflowStepTrigger() {
 		t.mockWorkflowFactory,
 	)
 
-	success, err := workflowService.RunWorkflow(t.workflowSession)
-	t.True(success)
+	err := workflowService.RunWorkflow(t.workflowSession)
 	t.NoError(err)
 
 	t.workflowSession.AssertExpectations(t.T())
@@ -292,8 +293,7 @@ func (t *WorkflowRunnerTestSuite) TestPreStartZeroWorkflowStepTrigger() {
 		t.mockWorkflowFactory,
 	)
 
-	success, err := workflowService.RunWorkflow(t.workflowSession)
-	t.True(success)
+	err := workflowService.RunWorkflow(t.workflowSession)
 	t.NoError(err)
 
 	t.workflowSession.AssertExpectations(t.T())
@@ -311,8 +311,7 @@ func (t *WorkflowRunnerTestSuite) TestPostStartZeroWorkflowStepTrigger() {
 		t.mockWorkflowFactory,
 	)
 
-	success, err := workflowService.RunWorkflow(t.workflowSession)
-	t.True(success)
+	err := workflowService.RunWorkflow(t.workflowSession)
 	t.NoError(err)
 
 	t.workflowSession.AssertExpectations(t.T())
@@ -330,8 +329,7 @@ func (t *WorkflowRunnerTestSuite) TestPreStopZeroWorkflowStepTrigger() {
 		t.mockWorkflowFactory,
 	)
 
-	success, err := workflowService.RunWorkflow(t.workflowSession)
-	t.True(success)
+	err := workflowService.RunWorkflow(t.workflowSession)
 	t.NoError(err)
 
 	t.workflowSession.AssertExpectations(t.T())
@@ -349,8 +347,7 @@ func (t *WorkflowRunnerTestSuite) TestPreDestroyZeroWorkflowStepTrigger() {
 		t.mockWorkflowFactory,
 	)
 
-	success, err := workflowService.RunWorkflow(t.workflowSession)
-	t.True(success)
+	err := workflowService.RunWorkflow(t.workflowSession)
 	t.NoError(err)
 
 	t.workflowSession.AssertExpectations(t.T())
@@ -368,8 +365,7 @@ func (t *WorkflowRunnerTestSuite) TestFirstPreStartNonZeroWorkflowStepTrigger() 
 		t.mockWorkflowFactory,
 	)
 
-	success, err := workflowService.RunWorkflow(t.workflowSession)
-	t.False(success)
+	err := workflowService.RunWorkflow(t.workflowSession)
 	t.NoError(err)
 
 	t.workflowSession.AssertExpectations(t.T())
@@ -388,8 +384,7 @@ func (t *WorkflowRunnerTestSuite) TestPreStartNonZeroWorkflowStepTrigger() {
 		t.mockWorkflowFactory,
 	)
 
-	success, err := workflowService.RunWorkflow(t.workflowSession)
-	t.False(success)
+	err := workflowService.RunWorkflow(t.workflowSession)
 	t.NoError(err)
 
 	t.workflowSession.AssertExpectations(t.T())
@@ -407,8 +402,7 @@ func (t *WorkflowRunnerTestSuite) TestPostStartNonZeroWorkflowStepTrigger() {
 		t.mockWorkflowFactory,
 	)
 
-	success, err := workflowService.RunWorkflow(t.workflowSession)
-	t.False(success)
+	err := workflowService.RunWorkflow(t.workflowSession)
 	t.NoError(err)
 
 	t.workflowSession.AssertExpectations(t.T())
@@ -426,8 +420,7 @@ func (t *WorkflowRunnerTestSuite) TestPreStopNonZeroWorkflowStepTrigger() {
 		t.mockWorkflowFactory,
 	)
 
-	success, err := workflowService.RunWorkflow(t.workflowSession)
-	t.False(success)
+	err := workflowService.RunWorkflow(t.workflowSession)
 	t.NoError(err)
 
 	t.workflowSession.AssertExpectations(t.T())
@@ -445,8 +438,7 @@ func (t *WorkflowRunnerTestSuite) TestPreDestroyNonZeroWorkflowStepTrigger() {
 		t.mockWorkflowFactory,
 	)
 
-	success, err := workflowService.RunWorkflow(t.workflowSession)
-	t.False(success)
+	err := workflowService.RunWorkflow(t.workflowSession)
 	t.NoError(err)
 
 	t.workflowSession.AssertExpectations(t.T())
@@ -455,137 +447,16 @@ func (t *WorkflowRunnerTestSuite) TestPreDestroyNonZeroWorkflowStepTrigger() {
 	t.mockWorkflowOrchestrator.AssertExpectations(t.T())
 }
 
-//func (t *WorkflowRunnerTestSuite) testUnknownWorkflowResult(workflow commonworkflow.WorkflowName) {
-//	serviceNameContextValueName := interceptors.ServiceName(interceptors.ServiceNameContextValueName)
-//	containerNameContextValueName := interceptors.ContainerName(interceptors.ContainerNameContextValueName)
-//	fullContainerNameContextValueName := interceptors.ContainerName(interceptors.FullContainerNameContextValueName)
-//
-//	ctx := context.Background()
-//	ctx = context.WithValue(ctx, serviceNameContextValueName, "test_service")
-//	ctx = context.WithValue(ctx, containerNameContextValueName, "service-1")
-//	ctx = context.WithValue(ctx, fullContainerNameContextValueName, "test_service-1")
-//
-//	t.mockGrpcServer.On("Context").Return(ctx)
-//
-//	t.mockEventManager.On("Publish", &wms_types.WorkflowStartedEvent{
-//		BaseWorkflowEvent: wms_types.BaseWorkflowEvent{
-//			ServiceName:       "test_service",
-//			ContainerName:     "service-1",
-//			FullContainerName: "test_service-1",
-//			WorkflowName:      workflow,
-//		},
-//	}).Return()
-//
-//	t.mockWorkflowFactory.On("Make", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(t.mockWorkflowOrchestrator, nil)
-//
-//	t.mockGrpcServer.On("Recv").Return(&services.RunWorkflowStreamRequest{
-//		Request: &services.RunWorkflowStreamRequest_RunRequest{
-//			RunRequest: &services.WorkflowRunRequest{
-//				WorkflowName: workflow.String(),
-//			},
-//		},
-//	}, nil).Once()
-//
-//	t.mockWorkflowOrchestrator.On("StepIterator").Return(func(yield func(wms_types.Step) bool) {
-//		step := &wms.MockStep{}
-//		step.On("GetID").Return("12345")
-//		step.On("GetName").Return("test")
-//		step.On("GetCommand").Return("/bin/sh")
-//		step.On("GetArguments").Return([]string{"-c", "echo \"Hello World\""})
-//		step.On("GetWorkingDirectory").Return("/")
-//		step.On("GetShell").Return("/bin/sh")
-//
-//		step.On(
-//			"Trigger",
-//			mock.AnythingOfType("wms.StepTriggerLambda"),
-//			mock.AnythingOfType("wms.StepProgressLambda"),
-//			mock.AnythingOfType("wms.StepCompleteLambda"),
-//		).Run(func(args mock.Arguments) {
-//			// trigger
-//			t.mockEventManager.On("Publish", &wms_types.WorkflowStepStartedEvent{
-//				BaseWorkflowEvent: wms_types.BaseWorkflowEvent{
-//					ServiceName:       "test_service",
-//					ContainerName:     "service-1",
-//					FullContainerName: "test_service-1",
-//					WorkflowName:      workflow,
-//				},
-//				StepID:    "12345",
-//				Name:      "test",
-//				Command:   "/bin/sh",
-//				Arguments: []string{"-c", "echo \"Hello World\""},
-//				Cwd:       "/",
-//				Shell:     "/bin/sh",
-//			}).Return()
-//
-//			t.mockGrpcServer.On("Send", &services.WorkflowStreamResponse{
-//				Action: services.WorkflowAction_RUN_COMMAND_ACTION,
-//				RunCommand: &services.WorkflowRunCommand{
-//					Command:          "/bin/sh",
-//					Arguments:        []string{"-c", "echo \"Hello World\""},
-//					WorkingDirectory: "/",
-//				},
-//			}).Return(nil)
-//
-//			trigger, ok := args.Get(0).(wms_types.StepTriggerLambda)
-//			t.True(ok)
-//
-//			err := trigger()
-//			t.Nil(err)
-//
-//			// progress
-//			var exitCode uint32
-//
-//			t.mockGrpcServer.On("Recv").Return(&services.RunWorkflowStreamRequest{
-//				Request: &services.RunWorkflowStreamRequest_StreamRequest{
-//					StreamRequest: &services.WorkflowStreamRequest{
-//						Result: -9999,
-//						RunCommandResult: &services.WorkflowRunResult{
-//							Stdout:   "Hello World",
-//							Stderr:   "",
-//							ExitCode: &exitCode,
-//						},
-//					},
-//				},
-//			}, nil)
-//
-//			progress, ok := args.Get(1).(wms_types.StepProgressLambda)
-//			t.True(ok)
-//
-//			_, err = progress()
-//			t.Error(err)
-//		}).Return(errors.New("unknown result"))
-//
-//		yield(step)
-//	})
-//
-//	t.mockEventManager.On("Publish", &wms_types.WorkflowErrorEvent{
-//		BaseWorkflowEvent: wms_types.BaseWorkflowEvent{
-//			ServiceName:       "test_service",
-//			ContainerName:     "service-1",
-//			FullContainerName: "test_service-1",
-//			WorkflowName:      workflow,
-//		},
-//		Err: errors.New("unknown result"),
-//	}).Return()
-//}
-
 func (t *WorkflowRunnerTestSuite) testServerRecvErrorFor(workflow commonworkflow.WorkflowName) {
-	//serviceNameContextValueName := interceptors.ServiceName(interceptors.ServiceNameContextValueName)
-	//containerNameContextValueName := interceptors.ContainerName(interceptors.ContainerNameContextValueName)
-	//fullContainerNameContextValueName := interceptors.ContainerName(interceptors.FullContainerNameContextValueName)
-	//
-	//ctx := context.Background()
-	//ctx = context.WithValue(ctx, serviceNameContextValueName, "test_service")
-	//ctx = context.WithValue(ctx, containerNameContextValueName, "service-1")
-	//ctx = context.WithValue(ctx, fullContainerNameContextValueName, "test_service-1")
-
 	t.workflowSession.On("GetServiceName").Return("test_service")
 	t.workflowSession.On("GetContainerName").Return("service-1")
 	t.workflowSession.On("GetFullContainerName").Return("test_service-1")
 	t.workflowSession.On("GetWorkflowName").Return(workflow)
 	t.workflowSession.On("GetWorkingDirectory").Return("/", nil)
 
-	//t.mockGrpcServer.On("Context").Return(ctx)
+	t.workflowSession.On("HasServiceWorkflowRun", "test_service").Return(false, nil)
+	t.workflowSession.On("HasFirstContainerWorkflowRun").Return(false)
+	t.workflowSession.On("MarkCompletion").Return(nil)
 
 	t.mockEventManager.On("Publish", &wms_types.WorkflowStartedEvent{
 		BaseWorkflowEvent: wms_types.BaseWorkflowEvent{
@@ -680,8 +551,7 @@ func (t *WorkflowRunnerTestSuite) TestFirstPreStartRecvError() {
 		t.mockWorkflowFactory,
 	)
 
-	success, err := workflowService.RunWorkflow(t.workflowSession)
-	t.False(success)
+	err := workflowService.RunWorkflow(t.workflowSession)
 	t.Error(err)
 
 	t.mockEventManager.AssertExpectations(t.T())
@@ -698,8 +568,7 @@ func (t *WorkflowRunnerTestSuite) TestPreStartRecvError() {
 		t.mockWorkflowFactory,
 	)
 
-	success, err := workflowService.RunWorkflow(t.workflowSession)
-	t.False(success)
+	err := workflowService.RunWorkflow(t.workflowSession)
 	t.Error(err)
 
 	t.mockEventManager.AssertExpectations(t.T())
@@ -716,8 +585,7 @@ func (t *WorkflowRunnerTestSuite) TestPostStartRecvError() {
 		t.mockWorkflowFactory,
 	)
 
-	success, err := workflowService.RunWorkflow(t.workflowSession)
-	t.False(success)
+	err := workflowService.RunWorkflow(t.workflowSession)
 	t.Error(err)
 
 	t.mockEventManager.AssertExpectations(t.T())
@@ -734,8 +602,7 @@ func (t *WorkflowRunnerTestSuite) TestPreStopRecvError() {
 		t.mockWorkflowFactory,
 	)
 
-	success, err := workflowService.RunWorkflow(t.workflowSession)
-	t.False(success)
+	err := workflowService.RunWorkflow(t.workflowSession)
 	t.Error(err)
 
 	t.mockEventManager.AssertExpectations(t.T())
@@ -752,117 +619,10 @@ func (t *WorkflowRunnerTestSuite) TestPreDestroyRecvError() {
 		t.mockWorkflowFactory,
 	)
 
-	success, err := workflowService.RunWorkflow(t.workflowSession)
-	t.False(success)
+	err := workflowService.RunWorkflow(t.workflowSession)
 	t.Error(err)
 
 	t.mockEventManager.AssertExpectations(t.T())
 	t.mockWorkflowFactory.AssertExpectations(t.T())
 	t.mockWorkflowOrchestrator.AssertExpectations(t.T())
 }
-
-//func (t *WorkflowRunnerTestSuite) TestFirstPreStartUnknownWorkflowResult() {
-//	t.testUnknownWorkflowResult(commonworkflow.FirstPreStartContainer)
-//
-//	workflowService := NewWorkflowService(
-//		t.soloCtx,
-//		t.mockEventManager,
-//		t.mockOrchestrator,
-//		t.mockWorkflowFactory,
-//		t.mockWorkflowExecTracker,
-//		t.mockWorkflowRunner,
-//	)
-//
-//	err := workflowService.RunWorkflowStream(t.mockGrpcServer)
-//	t.Error(err)
-//
-//	t.mockEventManager.AssertExpectations(t.T())
-//	t.mockWorkflowFactory.AssertExpectations(t.T())
-//	t.mockWorkflowOrchestrator.AssertExpectations(t.T())
-//	t.mockGrpcServer.AssertExpectations(t.T())
-//}
-//
-//func (t *WorkflowRunnerTestSuite) TestPreStartUnknownWorkflowResult() {
-//	t.testUnknownWorkflowResult(commonworkflow.PreStartContainer)
-//
-//	workflowService := NewWorkflowService(
-//		t.soloCtx,
-//		t.mockEventManager,
-//		t.mockOrchestrator,
-//		t.mockWorkflowFactory,
-//		t.mockWorkflowExecTracker,
-//		t.mockWorkflowRunner,
-//	)
-//
-//	err := workflowService.RunWorkflowStream(t.mockGrpcServer)
-//	t.Error(err)
-//
-//	t.mockEventManager.AssertExpectations(t.T())
-//	t.mockWorkflowFactory.AssertExpectations(t.T())
-//	t.mockWorkflowOrchestrator.AssertExpectations(t.T())
-//	t.mockGrpcServer.AssertExpectations(t.T())
-//}
-//
-//func (t *WorkflowRunnerTestSuite) TestPostStartUnknownWorkflowResult() {
-//	t.testUnknownWorkflowResult(commonworkflow.PostStartContainer)
-//
-//	workflowService := NewWorkflowService(
-//		t.soloCtx,
-//		t.mockEventManager,
-//		t.mockOrchestrator,
-//		t.mockWorkflowFactory,
-//		t.mockWorkflowExecTracker,
-//		t.mockWorkflowRunner,
-//	)
-//
-//	err := workflowService.RunWorkflowStream(t.mockGrpcServer)
-//	t.Error(err)
-//
-//	t.mockEventManager.AssertExpectations(t.T())
-//	t.mockWorkflowFactory.AssertExpectations(t.T())
-//	t.mockWorkflowOrchestrator.AssertExpectations(t.T())
-//	t.mockGrpcServer.AssertExpectations(t.T())
-//}
-//
-//func (t *WorkflowRunnerTestSuite) TestPreStopUnknownWorkflowResult() {
-//	t.testUnknownWorkflowResult(commonworkflow.PreStopContainer)
-//
-//	workflowService := NewWorkflowService(
-//		t.soloCtx,
-//		t.mockEventManager,
-//		t.mockOrchestrator,
-//		t.mockWorkflowFactory,
-//		t.mockWorkflowExecTracker,
-//		t.mockWorkflowRunner,
-//	)
-//
-//	err := workflowService.RunWorkflowStream(t.mockGrpcServer)
-//	t.Error(err)
-//
-//	t.mockEventManager.AssertExpectations(t.T())
-//	t.mockWorkflowFactory.AssertExpectations(t.T())
-//	t.mockWorkflowOrchestrator.AssertExpectations(t.T())
-//	t.mockGrpcServer.AssertExpectations(t.T())
-//}
-//
-//func (t *WorkflowRunnerTestSuite) TestPreDestroyUnknownWorkflowResult() {
-//	t.testUnknownWorkflowResult(commonworkflow.PreDestroyContainer)
-//
-//	workflowService := NewWorkflowService(
-//		t.soloCtx,
-//		t.mockEventManager,
-//		t.mockOrchestrator,
-//		t.mockWorkflowFactory,
-//		t.mockWorkflowExecTracker,
-//		t.mockWorkflowRunner,
-//	)
-//
-//	err := workflowService.RunWorkflowStream(t.mockGrpcServer)
-//	t.Error(err)
-//
-//	t.mockEventManager.AssertExpectations(t.T())
-//	t.mockWorkflowFactory.AssertExpectations(t.T())
-//	t.mockWorkflowOrchestrator.AssertExpectations(t.T())
-//	t.mockGrpcServer.AssertExpectations(t.T())
-//}
-//

--- a/internal/pkg/impl/host/infra/grpc/mutual_tls_server_factory.go
+++ b/internal/pkg/impl/host/infra/grpc/mutual_tls_server_factory.go
@@ -12,30 +12,25 @@ import (
 	"google.golang.org/grpc/credentials"
 
 	"github.com/spaulg/solo/internal/pkg/impl/host/app/context"
-	events_types "github.com/spaulg/solo/internal/pkg/impl/host/app/event_manager/events"
 	"github.com/spaulg/solo/internal/pkg/impl/host/infra/certificate"
 	"github.com/spaulg/solo/internal/pkg/impl/host/infra/grpc/service_definitions"
-	wms3 "github.com/spaulg/solo/internal/pkg/impl/host/shared/wms"
 	"github.com/spaulg/solo/internal/pkg/types/host/app/wms"
 	project_types "github.com/spaulg/solo/internal/pkg/types/host/domain"
 )
 
 type MutualTLSServerFactory struct {
 	soloCtx              *context.CliContext
-	eventManager         events_types.Manager
 	certificateAuthority Authority
-	workflowRunner       wms3.WorkflowRunner
+	workflowRunner       service_definitions.WorkflowRunner
 }
 
 func NewMutualTLSServerFactory(
 	soloCtx *context.CliContext,
-	eventManager events_types.Manager,
 	certificateAuthority Authority,
-	workflowRunner wms3.WorkflowRunner,
+	workflowRunner service_definitions.WorkflowRunner,
 ) *MutualTLSServerFactory {
 	return &MutualTLSServerFactory{
 		soloCtx:              soloCtx,
-		eventManager:         eventManager,
 		certificateAuthority: certificateAuthority,
 		workflowRunner:       workflowRunner,
 	}
@@ -56,7 +51,6 @@ func (t *MutualTLSServerFactory) Build(
 
 	workflowService := service_definitions.NewWorkflowService(
 		t.soloCtx,
-		t.eventManager,
 		orchestrator,
 		workflowExecutionTracker,
 		t.workflowRunner,

--- a/internal/pkg/impl/host/infra/grpc/mutual_tls_server_factory_test.go
+++ b/internal/pkg/impl/host/infra/grpc/mutual_tls_server_factory_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/spaulg/solo/internal/pkg/impl/host/domain"
 	domain_config "github.com/spaulg/solo/internal/pkg/impl/host/domain/config"
 	"github.com/spaulg/solo/test"
-	"github.com/spaulg/solo/test/mocks/host/app/events"
 	"github.com/spaulg/solo/test/mocks/host/app/wms"
 	"github.com/spaulg/solo/test/mocks/host/domain/project"
 	"github.com/spaulg/solo/test/mocks/host/infra/certificate"
@@ -28,14 +27,12 @@ type MutualTLSServerFactoryTestSuite struct {
 	soloCtx                  *cli_context.CliContext
 	mockProject              *project.MockProject
 	mockLogHandler           *logging.MockHandler
-	mockEventManager         *events.MockEventManager
 	mockCertificateAuthority *certificate.MockAuthority
 	mockWorkflowRunner       *wms.MockWorkflowRunner
 }
 
 func (t *MutualTLSServerFactoryTestSuite) SetupTest() {
 	t.mockProject = &project.MockProject{}
-	t.mockEventManager = &events.MockEventManager{}
 	t.mockCertificateAuthority = &certificate.MockAuthority{}
 	t.mockWorkflowRunner = &wms.MockWorkflowRunner{}
 
@@ -61,7 +58,6 @@ func (t *MutualTLSServerFactoryTestSuite) SetupTest() {
 func (t *MutualTLSServerFactoryTestSuite) TestNewMutualTLSServerFactory() {
 	serverFactory := NewMutualTLSServerFactory(
 		t.soloCtx,
-		t.mockEventManager,
 		t.mockCertificateAuthority,
 		t.mockWorkflowRunner,
 	)

--- a/internal/pkg/impl/host/infra/grpc/service_definitions/workflow_runner.go
+++ b/internal/pkg/impl/host/infra/grpc/service_definitions/workflow_runner.go
@@ -1,0 +1,9 @@
+package service_definitions
+
+import (
+	"github.com/spaulg/solo/internal/pkg/impl/host/shared/wms"
+)
+
+type WorkflowRunner interface {
+	RunWorkflow(workflowSession wms.WorkflowSession) error
+}

--- a/internal/pkg/impl/host/infra/grpc/service_definitions/workflow_service.go
+++ b/internal/pkg/impl/host/infra/grpc/service_definitions/workflow_service.go
@@ -9,30 +9,25 @@ import (
 	commonworkflow "github.com/spaulg/solo/internal/pkg/impl/common/domain/wms"
 	"github.com/spaulg/solo/internal/pkg/impl/common/infra/grpc/services"
 	solo_context "github.com/spaulg/solo/internal/pkg/impl/host/app/context"
-	events_types "github.com/spaulg/solo/internal/pkg/impl/host/app/event_manager/events"
-	wms3 "github.com/spaulg/solo/internal/pkg/impl/host/shared/wms"
-	"github.com/spaulg/solo/internal/pkg/types/host/app/wms"
+	wms_types "github.com/spaulg/solo/internal/pkg/types/host/app/wms"
 )
 
 type WorkflowServerImpl struct {
 	soloCtx *solo_context.CliContext
 	services.UnimplementedWorkflowServer
-	eventManager        events_types.Manager
 	orchestrator        ContainerImageWorkingDirectoryResolver
-	workflowExecTracker wms.WorkflowExecTracker
-	workflowRunner      wms3.WorkflowRunner
+	workflowExecTracker wms_types.WorkflowExecTracker
+	workflowRunner      WorkflowRunner
 }
 
 func NewWorkflowService(
 	soloCtx *solo_context.CliContext,
-	eventManager events_types.Manager,
 	orchestrator ContainerImageWorkingDirectoryResolver,
-	workflowExecTracker wms.WorkflowExecTracker,
-	workflowRunner wms3.WorkflowRunner,
+	workflowExecTracker wms_types.WorkflowExecTracker,
+	workflowRunner WorkflowRunner,
 ) *WorkflowServerImpl {
 	return &WorkflowServerImpl{
 		soloCtx:             soloCtx,
-		eventManager:        eventManager,
 		orchestrator:        orchestrator,
 		workflowExecTracker: workflowExecTracker,
 		workflowRunner:      workflowRunner,
@@ -49,68 +44,31 @@ func (t WorkflowServerImpl) RunWorkflowStream(
 
 	switch request := message.Request.(type) {
 	case *services.RunWorkflowStreamRequest_RunRequest:
-		workflowName := commonworkflow.WorkflowNameFromString(request.RunRequest.WorkflowName)
 		bidiStreamServer := NewRunWorkflowStreamWrapper(server)
+		workflowName := commonworkflow.WorkflowNameFromString(request.RunRequest.WorkflowName)
 
-		workflowSession, err := NewWorkflowSession(
-			t.soloCtx,
-			workflowName,
-			bidiStreamServer,
-			t.workflowExecTracker,
-			t.orchestrator,
-		)
-
-		if err != nil {
-			return fmt.Errorf("failed to create workflow session: %w", err)
-		}
-
-		return t.handleRunRequest(bidiStreamServer, workflowSession)
+		return t.handleRunWorkflowRequest(workflowName, bidiStreamServer)
 	default:
 		return errors.New("unsupported first message")
 	}
 }
 
-func (t WorkflowServerImpl) handleRunRequest(
+func (t WorkflowServerImpl) handleRunWorkflowRequest(
+	workflowName commonworkflow.WorkflowName,
 	server grpc.BidiStreamingServer[services.WorkflowStreamRequest, services.WorkflowStreamResponse],
-	workflowSession *WorkflowSession,
 ) error {
-	// Handle previously run once-only workflows
-	hasServiceWorkflowRun, err := workflowSession.HasServiceWorkflowRun(workflowSession.GetServiceName())
+
+	workflowSession, err := NewWorkflowSession(
+		t.soloCtx,
+		workflowName,
+		server,
+		t.workflowExecTracker,
+		t.orchestrator,
+	)
+
 	if err != nil {
-		return fmt.Errorf("failed to check if service workflow has run: %w", err)
+		return fmt.Errorf("failed to create workflow session: %w", err)
 	}
 
-	hasFirstContainerWorkflowRun := workflowSession.HasFirstContainerWorkflowRun()
-
-	if hasServiceWorkflowRun || hasFirstContainerWorkflowRun {
-		t.eventManager.Publish(&wms.WorkflowSkippedEvent{
-			BaseWorkflowEvent: wms.BaseWorkflowEvent{
-				ServiceName:       workflowSession.GetServiceName(),
-				ContainerName:     workflowSession.GetContainerName(),
-				FullContainerName: workflowSession.GetFullContainerName(),
-				WorkflowName:      workflowSession.GetWorkflowName(),
-			},
-			Successful: true,
-		})
-	} else {
-		workflowSuccess, err := t.workflowRunner.RunWorkflow(workflowSession)
-
-		if err != nil {
-			return err
-		}
-
-		t.eventManager.Publish(&wms.WorkflowCompleteEvent{
-			BaseWorkflowEvent: wms.BaseWorkflowEvent{
-				ServiceName:       workflowSession.GetServiceName(),
-				ContainerName:     workflowSession.GetContainerName(),
-				FullContainerName: workflowSession.GetFullContainerName(),
-				WorkflowName:      workflowSession.GetWorkflowName(),
-			},
-			Successful: workflowSuccess,
-		})
-	}
-
-	return server.Send(&services.WorkflowStreamResponse{
-		Action: services.WorkflowAction_COMPLETE_ACTION,
-	})
+	return t.workflowRunner.RunWorkflow(workflowSession)
 }

--- a/internal/pkg/impl/host/infra/grpc/service_definitions/workflow_service_test.go
+++ b/internal/pkg/impl/host/infra/grpc/service_definitions/workflow_service_test.go
@@ -15,10 +15,8 @@ import (
 	"github.com/spaulg/solo/internal/pkg/impl/host/domain"
 	domain_config "github.com/spaulg/solo/internal/pkg/impl/host/domain/config"
 	"github.com/spaulg/solo/internal/pkg/impl/host/infra/grpc/interceptors"
-	wms_types "github.com/spaulg/solo/internal/pkg/types/host/app/wms"
 	"github.com/spaulg/solo/test"
 	"github.com/spaulg/solo/test/mocks/grpc"
-	"github.com/spaulg/solo/test/mocks/host/app/events"
 	"github.com/spaulg/solo/test/mocks/host/app/wms"
 	"github.com/spaulg/solo/test/mocks/host/domain/project"
 	"github.com/spaulg/solo/test/mocks/host/infra/container"
@@ -35,7 +33,6 @@ type WorkflowServiceTestSuite struct {
 	soloCtx                 *cli_context.CliContext
 	mockProject             *project.MockProject
 	mockLogHandler          *logging.MockHandler
-	mockEventManager        *events.MockEventManager
 	mockWorkflowExecTracker *wms.MockWorkflowExecTracker
 	mockOrchestrator        *container.MockOrchestrator
 	mockGrpcServer          *grpc.MockBidiStreamingServer[services.RunWorkflowStreamRequest, services.WorkflowStreamResponse]
@@ -43,7 +40,6 @@ type WorkflowServiceTestSuite struct {
 }
 
 func (t *WorkflowServiceTestSuite) SetupTest() {
-	t.mockEventManager = &events.MockEventManager{}
 	t.mockProject = &project.MockProject{}
 	t.mockOrchestrator = &container.MockOrchestrator{}
 	t.mockGrpcServer = &grpc.MockBidiStreamingServer[services.RunWorkflowStreamRequest, services.WorkflowStreamResponse]{}
@@ -72,7 +68,6 @@ func (t *WorkflowServiceTestSuite) SetupTest() {
 func (t *WorkflowServiceTestSuite) TestRecvRunWorkflowStreamRequestFailed() {
 	workflowService := NewWorkflowService(
 		t.soloCtx,
-		t.mockEventManager,
 		t.mockOrchestrator,
 		t.mockWorkflowExecTracker,
 		t.mockWorkflowRunner,
@@ -85,7 +80,6 @@ func (t *WorkflowServiceTestSuite) TestRecvRunWorkflowStreamRequestFailed() {
 	err := workflowService.RunWorkflowStream(t.mockGrpcServer)
 	t.Error(err)
 
-	t.mockEventManager.AssertExpectations(t.T())
 	t.mockOrchestrator.AssertExpectations(t.T())
 	t.mockGrpcServer.AssertExpectations(t.T())
 	t.mockWorkflowExecTracker.AssertExpectations(t.T())
@@ -95,7 +89,6 @@ func (t *WorkflowServiceTestSuite) TestRecvRunWorkflowStreamRequestFailed() {
 func (t *WorkflowServiceTestSuite) TestRecvRunWorkflowStreamRequestMessageUnsupported() {
 	workflowService := NewWorkflowService(
 		t.soloCtx,
-		t.mockEventManager,
 		t.mockOrchestrator,
 		t.mockWorkflowExecTracker,
 		t.mockWorkflowRunner,
@@ -109,7 +102,6 @@ func (t *WorkflowServiceTestSuite) TestRecvRunWorkflowStreamRequestMessageUnsupp
 	err := workflowService.RunWorkflowStream(t.mockGrpcServer)
 	t.ErrorContains(err, "unsupported first message")
 
-	t.mockEventManager.AssertExpectations(t.T())
 	t.mockOrchestrator.AssertExpectations(t.T())
 	t.mockGrpcServer.AssertExpectations(t.T())
 	t.mockWorkflowExecTracker.AssertExpectations(t.T())
@@ -138,24 +130,10 @@ func (t *WorkflowServiceTestSuite) TestFirstContainerCompleteSkipsWorkflow() {
 		},
 	}, nil).Once()
 
-	t.mockEventManager.On("Publish", &wms_types.WorkflowSkippedEvent{
-		BaseWorkflowEvent: wms_types.BaseWorkflowEvent{
-			ServiceName:       "test_service",
-			ContainerName:     "service-1",
-			FullContainerName: "test_service-1",
-			WorkflowName:      commonworkflow.FirstPreStartContainer,
-		},
-		Successful: true,
-	}).Return()
-
-	t.mockGrpcServer.On("Send", &services.WorkflowStreamResponse{
-		Action:     services.WorkflowAction_COMPLETE_ACTION,
-		RunCommand: nil,
-	}).Return(nil)
+	t.mockWorkflowRunner.On("RunWorkflow", mock.AnythingOfType("*service_definitions.WorkflowSession")).Return(nil)
 
 	workflowService := NewWorkflowService(
 		t.soloCtx,
-		t.mockEventManager,
 		t.mockOrchestrator,
 		t.mockWorkflowExecTracker,
 		t.mockWorkflowRunner,
@@ -164,7 +142,6 @@ func (t *WorkflowServiceTestSuite) TestFirstContainerCompleteSkipsWorkflow() {
 	err := workflowService.RunWorkflowStream(t.mockGrpcServer)
 	t.NoError(err)
 
-	t.mockEventManager.AssertExpectations(t.T())
 	t.mockOrchestrator.AssertExpectations(t.T())
 	t.mockGrpcServer.AssertExpectations(t.T())
 	t.mockWorkflowExecTracker.AssertExpectations(t.T())
@@ -196,26 +173,10 @@ func (t *WorkflowServiceTestSuite) TestRunWorkflowSucceeds() {
 	t.mockWorkflowRunner.On(
 		"RunWorkflow",
 		mock.AnythingOfType("*service_definitions.WorkflowSession"),
-	).Return(true, nil).Once()
-
-	t.mockEventManager.On("Publish", &wms_types.WorkflowCompleteEvent{
-		BaseWorkflowEvent: wms_types.BaseWorkflowEvent{
-			ServiceName:       "test_service",
-			ContainerName:     "service-1",
-			FullContainerName: "test_service-1",
-			WorkflowName:      commonworkflow.FirstPreStartContainer,
-		},
-		Successful: true,
-	}).Return()
-
-	t.mockGrpcServer.On("Send", &services.WorkflowStreamResponse{
-		Action:     services.WorkflowAction_COMPLETE_ACTION,
-		RunCommand: nil,
-	}).Return(nil)
+	).Return(nil).Once()
 
 	workflowService := NewWorkflowService(
 		t.soloCtx,
-		t.mockEventManager,
 		t.mockOrchestrator,
 		t.mockWorkflowExecTracker,
 		t.mockWorkflowRunner,
@@ -224,7 +185,6 @@ func (t *WorkflowServiceTestSuite) TestRunWorkflowSucceeds() {
 	err := workflowService.RunWorkflowStream(t.mockGrpcServer)
 	t.NoError(err)
 
-	t.mockEventManager.AssertExpectations(t.T())
 	t.mockOrchestrator.AssertExpectations(t.T())
 	t.mockGrpcServer.AssertExpectations(t.T())
 	t.mockWorkflowExecTracker.AssertExpectations(t.T())
@@ -256,11 +216,10 @@ func (t *WorkflowServiceTestSuite) TestRunWorkflowFails() {
 	t.mockWorkflowRunner.On(
 		"RunWorkflow",
 		mock.AnythingOfType("*service_definitions.WorkflowSession"),
-	).Return(false, errors.New("mock workflow error")).Once()
+	).Return(errors.New("mock workflow error")).Once()
 
 	workflowService := NewWorkflowService(
 		t.soloCtx,
-		t.mockEventManager,
 		t.mockOrchestrator,
 		t.mockWorkflowExecTracker,
 		t.mockWorkflowRunner,
@@ -269,7 +228,6 @@ func (t *WorkflowServiceTestSuite) TestRunWorkflowFails() {
 	err := workflowService.RunWorkflowStream(t.mockGrpcServer)
 	t.ErrorContains(err, "mock workflow error")
 
-	t.mockEventManager.AssertExpectations(t.T())
 	t.mockOrchestrator.AssertExpectations(t.T())
 	t.mockGrpcServer.AssertExpectations(t.T())
 	t.mockWorkflowExecTracker.AssertExpectations(t.T())

--- a/internal/pkg/impl/host/infra/grpc/service_definitions/workflow_session.go
+++ b/internal/pkg/impl/host/infra/grpc/service_definitions/workflow_session.go
@@ -168,3 +168,9 @@ func (t *WorkflowSession) RecvCommandResponse() (*wms_shared.CommandResponse, er
 		ExitCode: exitCodePtr,
 	}, nil
 }
+
+func (t *WorkflowSession) MarkCompletion() error {
+	return t.server.Send(&services.WorkflowStreamResponse{
+		Action: services.WorkflowAction_COMPLETE_ACTION,
+	})
+}

--- a/internal/pkg/impl/host/infra/grpc/service_definitions/workflow_session_test.go
+++ b/internal/pkg/impl/host/infra/grpc/service_definitions/workflow_session_test.go
@@ -456,3 +456,36 @@ func (t *WorkflowSessionTestSuite) TestRecvWithExitCode() {
 	t.Equal("stderr data", response.Stderr)
 	t.Equal(&expectedExitCode, response.ExitCode)
 }
+
+func (t *WorkflowSessionTestSuite) TestMarkComplete() {
+	serviceNameContextValueName := interceptors.ServiceName(interceptors.ServiceNameContextValueName)
+	fullContainerNameContextValueName := interceptors.ContainerName(interceptors.FullContainerNameContextValueName)
+	containerNameContextValueName := interceptors.ContainerName(interceptors.ContainerNameContextValueName)
+	firstContainerCompleteValueName := interceptors.FirstContainerComplete(commonworkflow.FirstPreStartContainer)
+
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, serviceNameContextValueName, "test_service")
+	ctx = context.WithValue(ctx, fullContainerNameContextValueName, "test_service-1")
+	ctx = context.WithValue(ctx, containerNameContextValueName, "service-1")
+	ctx = context.WithValue(ctx, firstContainerCompleteValueName, "false")
+
+	t.mockGrpcServer.On("Context").Return(ctx)
+
+	workflowSession, err := NewWorkflowSession(
+		t.soloCtx,
+		commonworkflow.FirstPreStartContainer,
+		t.mockGrpcServer,
+		t.mockWorkflowExecTracker,
+		t.mockOrchestrator,
+	)
+
+	t.NotNil(workflowSession)
+	t.NoError(err)
+
+	t.mockGrpcServer.On("Send", &services.WorkflowStreamResponse{
+		Action: services.WorkflowAction_COMPLETE_ACTION,
+	}).Return(nil)
+
+	err = workflowSession.MarkCompletion()
+	t.NoError(err)
+}

--- a/internal/pkg/impl/host/shared/wms/workflow_runner.go
+++ b/internal/pkg/impl/host/shared/wms/workflow_runner.go
@@ -1,5 +1,0 @@
-package wms
-
-type WorkflowRunner interface {
-	RunWorkflow(workflowSession WorkflowSession) (bool, error)
-}

--- a/internal/pkg/impl/host/shared/wms/workflow_session.go
+++ b/internal/pkg/impl/host/shared/wms/workflow_session.go
@@ -27,4 +27,5 @@ type WorkflowSession interface {
 
 	RunCommand(*RunCommandRequest) error
 	RecvCommandResponse() (*CommandResponse, error)
+	MarkCompletion() error
 }

--- a/solo.yml
+++ b/solo.yml
@@ -44,12 +44,13 @@ services:
     build:
       context: .
       dockerfile: ./examples/symfony-webapp/Dockerfile.php
-    command: /usr/sbin/php-fpm8.4 -FO
+    command: /usr/sbin/php-fpm8.5 -FO
     working_dir: /var/www/project
+
     volumes:
       - "composer:/root/.cache/composer"
       - "./examples/symfony-webapp:/var/www/project"
-      - "./examples/symfony-webapp/pool.conf:/etc/php/8.4/fpm/pool.d/www.conf"
+      - "./examples/symfony-webapp/pool.conf:/etc/php/8.5/fpm/pool.d/www.conf"
       - "./cmd/solo-entrypoint:/solo/cmd/solo-entrypoint"
       - "./internal:/solo/internal"
       - "./go.mod:/solo/go.mod"

--- a/test/mocks/host/app/wms/workflow_runner.go
+++ b/test/mocks/host/app/wms/workflow_runner.go
@@ -10,7 +10,7 @@ type MockWorkflowRunner struct {
 	mock.Mock
 }
 
-func (m *MockWorkflowRunner) RunWorkflow(workflowSession wms.WorkflowSession) (bool, error) {
+func (m *MockWorkflowRunner) RunWorkflow(workflowSession wms.WorkflowSession) error {
 	args := m.Called(workflowSession)
-	return args.Bool(0), args.Error(1)
+	return args.Error(0)
 }

--- a/test/mocks/host/infra/grpc/service_definitions/workflow_session.go
+++ b/test/mocks/host/infra/grpc/service_definitions/workflow_session.go
@@ -59,3 +59,8 @@ func (m *MockWorkflowSession) RecvCommandResponse() (*shared_wms.CommandResponse
 
 	return nil, args.Error(1)
 }
+
+func (m *MockWorkflowSession) MarkCompletion() error {
+	args := m.Called()
+	return args.Error(0)
+}


### PR DESCRIPTION
Remove GRPC service definition coupling on WMS event publication by moving business logic to workflow runner in the app layer.