### PR TITLE
Split the workflow execution tracker to a domain object and repository

### DIFF
--- a/internal/pkg/impl/host/app/project_control.go
+++ b/internal/pkg/impl/host/app/project_control.go
@@ -12,18 +12,20 @@ import (
 	"github.com/spaulg/solo/internal/pkg/impl/host/app/event_manager/events"
 	"github.com/spaulg/solo/internal/pkg/impl/host/app/project"
 	"github.com/spaulg/solo/internal/pkg/impl/host/app/wms"
+	"github.com/spaulg/solo/internal/pkg/impl/host/domain"
 	"github.com/spaulg/solo/internal/pkg/impl/host/infra/grpc"
 )
 
 const workflowExecTrackerFile = "workflow_exec_tracker.json"
 
 type ProjectControl struct {
-	soloCtx              *context.CliContext
-	eventManager         events.Manager
-	orchestratorFactory  OrchestratorFactory
-	grpcServerFactory    grpc.ServerFactory
-	workflowGuardFactory WorkflowGuardFactory
-	auditor              Auditor
+	soloCtx                     *context.CliContext
+	eventManager                events.Manager
+	orchestratorFactory         OrchestratorFactory
+	grpcServerFactory           grpc.ServerFactory
+	workflowGuardFactory        WorkflowGuardFactory
+	auditor                     Auditor
+	workflowExecTraceRepository domain.WorkflowExecTraceRepository
 }
 
 func NewProjectControl(
@@ -33,14 +35,16 @@ func NewProjectControl(
 	grpcServerFactory grpc.ServerFactory,
 	workflowGuardFactory WorkflowGuardFactory,
 	auditor Auditor,
+	workflowExecTraceRepository domain.WorkflowExecTraceRepository,
 ) *ProjectControl {
 	return &ProjectControl{
-		soloCtx:              soloCtx,
-		eventManager:         workflowManager,
-		orchestratorFactory:  orchestratorFactory,
-		grpcServerFactory:    grpcServerFactory,
-		workflowGuardFactory: workflowGuardFactory,
-		auditor:              auditor,
+		soloCtx:                     soloCtx,
+		eventManager:                workflowManager,
+		orchestratorFactory:         orchestratorFactory,
+		grpcServerFactory:           grpcServerFactory,
+		workflowGuardFactory:        workflowGuardFactory,
+		auditor:                     auditor,
+		workflowExecTraceRepository: workflowExecTraceRepository,
 	}
 }
 
@@ -139,8 +143,9 @@ func (t *ProjectControl) internalStart() error {
 		return nil
 	}
 
-	workflowExecutionTracker, err := wms.LoadWorkflowExecTracker(
+	workflowExecutionTracker, err := wms.NewWorkflowExecTracker(
 		t.soloCtx.Project.ResolveStateDirectory(workflowExecTrackerFile),
+		t.workflowExecTraceRepository,
 	)
 
 	if err != nil {
@@ -267,8 +272,9 @@ func (t *ProjectControl) internalStop() error {
 	}
 
 	if len(serviceStatus.RunningServices) > 0 {
-		workflowExecutionTracker, err := wms.LoadWorkflowExecTracker(
+		workflowExecutionTracker, err := wms.NewWorkflowExecTracker(
 			t.soloCtx.Project.ResolveStateDirectory(workflowExecTrackerFile),
+			t.workflowExecTraceRepository,
 		)
 
 		if err != nil {
@@ -353,8 +359,9 @@ func (t *ProjectControl) internalDestroy() error {
 		return fmt.Errorf("failed to check service status: %w", err)
 	}
 
-	workflowExecutionTracker, err := wms.LoadWorkflowExecTracker(
+	workflowExecutionTracker, err := wms.NewWorkflowExecTracker(
 		t.soloCtx.Project.ResolveStateDirectory(workflowExecTrackerFile),
+		t.workflowExecTraceRepository,
 	)
 
 	if err != nil {

--- a/internal/pkg/impl/host/app/project_control_factory.go
+++ b/internal/pkg/impl/host/app/project_control_factory.go
@@ -18,6 +18,7 @@ func ProjectControlFactory(soloCtx *context.CliContext) (*ProjectControl, error)
 	execEventRepository := repository.NewJSONFileRepository[*domain.ExecutionEvent]()
 	workflowLogMetaRepository := repository.NewJSONFileRepository[domain.WorkflowLogMeta]()
 	workflowStepLogMetaRepository := repository.NewJSONFileRepository[*domain.WorkflowStepLogMeta]()
+	workflowExecTraceRepository := repository.NewJSONFileRepository[*domain.WorkflowExecTrace]()
 	logWriter := repository.NewAppendFileStore()
 
 	auditor := audit.NewAuditor(
@@ -49,7 +50,15 @@ func ProjectControlFactory(soloCtx *context.CliContext) (*ProjectControl, error)
 	workflowGuardFactory := wms.NewWorkflowGuardFactory(soloCtx)
 
 	// Project control
-	projectControl := NewProjectControl(soloCtx, eventManager, orchestratorFactory, grpcServerFactory, workflowGuardFactory, auditor)
+	projectControl := NewProjectControl(
+		soloCtx,
+		eventManager,
+		orchestratorFactory,
+		grpcServerFactory,
+		workflowGuardFactory,
+		auditor,
+		workflowExecTraceRepository,
+	)
 
 	return projectControl, nil
 }

--- a/internal/pkg/impl/host/app/project_control_test.go
+++ b/internal/pkg/impl/host/app/project_control_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spaulg/solo/internal/pkg/impl/host/domain"
 	container_types "github.com/spaulg/solo/internal/pkg/impl/host/infra/container"
 	"github.com/spaulg/solo/test/mocks/host/app/audit"
+	"github.com/spaulg/solo/test/mocks/host/infra/repository"
 
 	"github.com/spaulg/solo/internal/pkg/impl/host/app/context"
 	domain_config_types "github.com/spaulg/solo/internal/pkg/impl/host/domain/config"
@@ -32,19 +33,20 @@ func TestProjectControlTestSuite(t *testing.T) {
 type ProjectControlTestSuite struct {
 	suite.Suite
 
-	soloCtx                  *context.CliContext
-	mockProject              *project.MockProject
-	mockOrchestratorFactory  *container.MockOrchestratorFactory
-	mockGrpcServerFactory    *grpc.MockGRPCServerFactory
-	mockWorkflowManager      *events.MockEventManager
-	mockOrchestrator         *container.MockOrchestrator
-	mockLogHandler           *logging.MockHandler
-	mockGrpcServer           *grpc.MockAsynchronousServer
-	mockWorkflowGuardFactory *wms.MockWorkflowGuardFactory
-	mockWorkflowGuard        *wms.MockWorkflowGuard
-	mockServices             *compose.MockServices
-	mockServiceConfig        *compose.MockServiceConfig
-	mockAuditor              *audit.MockAuditor
+	soloCtx                         *context.CliContext
+	mockProject                     *project.MockProject
+	mockOrchestratorFactory         *container.MockOrchestratorFactory
+	mockGrpcServerFactory           *grpc.MockGRPCServerFactory
+	mockWorkflowManager             *events.MockEventManager
+	mockOrchestrator                *container.MockOrchestrator
+	mockLogHandler                  *logging.MockHandler
+	mockGrpcServer                  *grpc.MockAsynchronousServer
+	mockWorkflowGuardFactory        *wms.MockWorkflowGuardFactory
+	mockWorkflowGuard               *wms.MockWorkflowGuard
+	mockServices                    *compose.MockServices
+	mockServiceConfig               *compose.MockServiceConfig
+	mockAuditor                     *audit.MockAuditor
+	mockWorkflowExecTraceRepository *repository.MockJSONFileRepository[*domain.WorkflowExecTrace]
 }
 
 func (t *ProjectControlTestSuite) SetupTest() {
@@ -79,6 +81,20 @@ func (t *ProjectControlTestSuite) SetupTest() {
 			},
 		},
 	}
+
+	t.mockWorkflowExecTraceRepository = &repository.MockJSONFileRepository[*domain.WorkflowExecTrace]{}
+	workflowExecTrace := domain.NewWorkflowExecTrace()
+
+	t.mockWorkflowExecTraceRepository.On(
+		"Load",
+		mock.AnythingOfType("string"),
+	).Return(workflowExecTrace, nil)
+
+	t.mockWorkflowExecTraceRepository.On(
+		"Save",
+		mock.AnythingOfType("string"),
+		mock.AnythingOfType("*domain.WorkflowExecTrace"),
+	).Return(nil)
 }
 
 func (t *ProjectControlTestSuite) TestStart_OrchestratorFactoryReturnsError() {
@@ -91,6 +107,7 @@ func (t *ProjectControlTestSuite) TestStart_OrchestratorFactoryReturnsError() {
 		t.mockGrpcServerFactory,
 		t.mockWorkflowGuardFactory,
 		t.mockAuditor,
+		t.mockWorkflowExecTraceRepository,
 	)
 
 	err := projectControl.Start()
@@ -117,6 +134,7 @@ func (t *ProjectControlTestSuite) TestStart_ServiceStatusReturnsError() {
 		t.mockGrpcServerFactory,
 		t.mockWorkflowGuardFactory,
 		t.mockAuditor,
+		t.mockWorkflowExecTraceRepository,
 	)
 
 	err := projectControl.Start()
@@ -157,6 +175,7 @@ func (t *ProjectControlTestSuite) TestStart_AllServicesAlreadyRunning() {
 		t.mockGrpcServerFactory,
 		t.mockWorkflowGuardFactory,
 		t.mockAuditor,
+		t.mockWorkflowExecTraceRepository,
 	)
 
 	err := projectControl.Start()
@@ -197,6 +216,7 @@ func (t *ProjectControlTestSuite) TestStart_GRPCServerFailsToBuild() {
 		t.mockGrpcServerFactory,
 		t.mockWorkflowGuardFactory,
 		t.mockAuditor,
+		t.mockWorkflowExecTraceRepository,
 	)
 
 	err := projectControl.Start()
@@ -238,6 +258,7 @@ func (t *ProjectControlTestSuite) TestStart_GRPCServerFailsToStart() {
 		t.mockGrpcServerFactory,
 		t.mockWorkflowGuardFactory,
 		t.mockAuditor,
+		t.mockWorkflowExecTraceRepository,
 	)
 
 	err := projectControl.Start()
@@ -287,6 +308,7 @@ func (t *ProjectControlTestSuite) TestStart_EntrypointCopyFails() {
 		t.mockGrpcServerFactory,
 		t.mockWorkflowGuardFactory,
 		t.mockAuditor,
+		t.mockWorkflowExecTraceRepository,
 	)
 
 	err := projectControl.Start()
@@ -336,6 +358,7 @@ func (t *ProjectControlTestSuite) TestStart_ContainerNamesFails() {
 		t.mockGrpcServerFactory,
 		t.mockWorkflowGuardFactory,
 		t.mockAuditor,
+		t.mockWorkflowExecTraceRepository,
 	)
 
 	err := projectControl.Start()
@@ -393,6 +416,7 @@ func (t *ProjectControlTestSuite) TestStart_ComposeUpFails() {
 		t.mockGrpcServerFactory,
 		t.mockWorkflowGuardFactory,
 		t.mockAuditor,
+		t.mockWorkflowExecTraceRepository,
 	)
 
 	err := projectControl.Start()
@@ -453,6 +477,7 @@ func (t *ProjectControlTestSuite) TestStart_GuardWaitFails() {
 		t.mockGrpcServerFactory,
 		t.mockWorkflowGuardFactory,
 		t.mockAuditor,
+		t.mockWorkflowExecTraceRepository,
 	)
 
 	err := projectControl.Start()
@@ -523,6 +548,7 @@ func (t *ProjectControlTestSuite) TestStart_Succeeds() {
 		t.mockGrpcServerFactory,
 		t.mockWorkflowGuardFactory,
 		t.mockAuditor,
+		t.mockWorkflowExecTraceRepository,
 	)
 
 	err := projectControl.Start()
@@ -556,6 +582,7 @@ func (t *ProjectControlTestSuite) TestStop_OrchestratorFactoryFails() {
 		t.mockGrpcServerFactory,
 		t.mockWorkflowGuardFactory,
 		t.mockAuditor,
+		t.mockWorkflowExecTraceRepository,
 	)
 
 	err := projectControl.Stop()
@@ -590,6 +617,7 @@ func (t *ProjectControlTestSuite) TestStop_ServicesStatusFails() {
 		t.mockGrpcServerFactory,
 		t.mockWorkflowGuardFactory,
 		t.mockAuditor,
+		t.mockWorkflowExecTraceRepository,
 	)
 
 	err := projectControl.Stop()
@@ -637,6 +665,7 @@ func (t *ProjectControlTestSuite) TestStop_GrpcServerBuildFails() {
 		t.mockGrpcServerFactory,
 		t.mockWorkflowGuardFactory,
 		t.mockAuditor,
+		t.mockWorkflowExecTraceRepository,
 	)
 
 	err := projectControl.Stop()
@@ -685,6 +714,7 @@ func (t *ProjectControlTestSuite) TestStop_GrpcServerStartFails() {
 		t.mockGrpcServerFactory,
 		t.mockWorkflowGuardFactory,
 		t.mockAuditor,
+		t.mockWorkflowExecTraceRepository,
 	)
 
 	err := projectControl.Stop()
@@ -737,6 +767,7 @@ func (t *ProjectControlTestSuite) TestStop_ContainerNamesFails() {
 		t.mockGrpcServerFactory,
 		t.mockWorkflowGuardFactory,
 		t.mockAuditor,
+		t.mockWorkflowExecTraceRepository,
 	)
 
 	err := projectControl.Stop()
@@ -795,6 +826,7 @@ func (t *ProjectControlTestSuite) TestStop_GuardWaitFails() {
 		t.mockGrpcServerFactory,
 		t.mockWorkflowGuardFactory,
 		t.mockAuditor,
+		t.mockWorkflowExecTraceRepository,
 	)
 
 	err := projectControl.Stop()
@@ -857,6 +889,7 @@ func (t *ProjectControlTestSuite) TestStop_ComposeStopFails() {
 		t.mockGrpcServerFactory,
 		t.mockWorkflowGuardFactory,
 		t.mockAuditor,
+		t.mockWorkflowExecTraceRepository,
 	)
 
 	err := projectControl.Stop()
@@ -926,6 +959,7 @@ func (t *ProjectControlTestSuite) TestStop_Succeeds() {
 		t.mockGrpcServerFactory,
 		t.mockWorkflowGuardFactory,
 		t.mockAuditor,
+		t.mockWorkflowExecTraceRepository,
 	)
 
 	err := projectControl.Stop()
@@ -960,6 +994,7 @@ func (t *ProjectControlTestSuite) TestDestroy_OrchestratorFactoryFails() {
 		t.mockGrpcServerFactory,
 		t.mockWorkflowGuardFactory,
 		t.mockAuditor,
+		t.mockWorkflowExecTraceRepository,
 	)
 
 	err := projectControl.Destroy()
@@ -993,6 +1028,7 @@ func (t *ProjectControlTestSuite) TestDestroy_ServicesStatusFails() {
 		t.mockGrpcServerFactory,
 		t.mockWorkflowGuardFactory,
 		t.mockAuditor,
+		t.mockWorkflowExecTraceRepository,
 	)
 
 	err := projectControl.Destroy()
@@ -1038,6 +1074,7 @@ func (t *ProjectControlTestSuite) TestDestroy_GrpcServerBuildFails() {
 		t.mockGrpcServerFactory,
 		t.mockWorkflowGuardFactory,
 		t.mockAuditor,
+		t.mockWorkflowExecTraceRepository,
 	)
 
 	err := projectControl.Destroy()
@@ -1085,6 +1122,7 @@ func (t *ProjectControlTestSuite) TestDestroy_GrpcServerStartFails() {
 		t.mockGrpcServerFactory,
 		t.mockWorkflowGuardFactory,
 		t.mockAuditor,
+		t.mockWorkflowExecTraceRepository,
 	)
 
 	err := projectControl.Destroy()
@@ -1136,6 +1174,7 @@ func (t *ProjectControlTestSuite) TestDestroy_ContainerNamesFails() {
 		t.mockGrpcServerFactory,
 		t.mockWorkflowGuardFactory,
 		t.mockAuditor,
+		t.mockWorkflowExecTraceRepository,
 	)
 
 	err := projectControl.Destroy()
@@ -1191,6 +1230,7 @@ func (t *ProjectControlTestSuite) TestDestroy_GuardWaitFails() {
 		t.mockGrpcServerFactory,
 		t.mockWorkflowGuardFactory,
 		t.mockAuditor,
+		t.mockWorkflowExecTraceRepository,
 	)
 
 	err := projectControl.Destroy()
@@ -1254,6 +1294,7 @@ func (t *ProjectControlTestSuite) TestDestroy_ComposeDownFails() {
 		t.mockGrpcServerFactory,
 		t.mockWorkflowGuardFactory,
 		t.mockAuditor,
+		t.mockWorkflowExecTraceRepository,
 	)
 
 	err := projectControl.Destroy()
@@ -1326,6 +1367,7 @@ func (t *ProjectControlTestSuite) TestDestroy_Succeeds() {
 		t.mockGrpcServerFactory,
 		t.mockWorkflowGuardFactory,
 		t.mockAuditor,
+		t.mockWorkflowExecTraceRepository,
 	)
 
 	err := projectControl.Destroy()

--- a/internal/pkg/impl/host/app/wms/workflow_exec_tracker.go
+++ b/internal/pkg/impl/host/app/wms/workflow_exec_tracker.go
@@ -1,86 +1,57 @@
 package wms
 
 import (
-	"encoding/json"
-	"errors"
 	"fmt"
-	"os"
 	"sync"
 
 	commonworkflow "github.com/spaulg/solo/internal/pkg/impl/common/domain/wms"
+	"github.com/spaulg/solo/internal/pkg/impl/host/domain"
 )
 
 type WorkflowExecTracker struct {
-	mu           sync.Mutex
-	workflowMap  map[string]struct{}
-	workflowList []string
-	filePath     string
+	mu            sync.Mutex
+	workflowTrace *domain.WorkflowExecTrace
+	repository    domain.WorkflowExecTraceRepository
+	filePath      string
 }
 
-func LoadWorkflowExecTracker(filePath string) (*WorkflowExecTracker, error) {
-	tracker := &WorkflowExecTracker{
-		workflowMap:  make(map[string]struct{}),
-		workflowList: make([]string, 0),
-		filePath:     filePath,
-	}
-
-	if _, err := os.Stat(tracker.filePath); err != nil {
-		if !errors.Is(err, os.ErrNotExist) {
-			return nil, err
-		}
-
-		return tracker, nil
-	}
-
-	// Load existing workflowMap from file if it exists
-	data, err := os.ReadFile(tracker.filePath)
+func NewWorkflowExecTracker(
+	filePath string,
+	repository domain.WorkflowExecTraceRepository,
+) (*WorkflowExecTracker, error) {
+	workflowTrace, err := repository.Load(filePath)
 	if err != nil {
 		return nil, err
+	} else if workflowTrace == nil {
+		workflowTrace = domain.NewWorkflowExecTrace()
 	}
 
-	if err := json.Unmarshal(data, &tracker.workflowList); err != nil {
-		return nil, err
-	}
-
-	for _, key := range tracker.workflowList {
-		tracker.workflowMap[key] = struct{}{}
-	}
-
-	return tracker, nil
+	return &WorkflowExecTracker{
+		filePath:      filePath,
+		workflowTrace: workflowTrace,
+		repository:    repository,
+	}, nil
 }
 
 func (t *WorkflowExecTracker) Save() error {
-	// Marshal to JSON
-	data, err := json.Marshal(t.workflowList)
-	if err != nil {
-		return fmt.Errorf("failed to marshal workflow list: %w", err)
-	}
-
-	// Write to file
-	if err := os.WriteFile(t.filePath, data, 0600); err != nil {
-		return fmt.Errorf("failed to write workflow list to file: %w", err)
-	}
-
-	return nil
+	return t.repository.Save(t.filePath, t.workflowTrace)
 }
 
-func (t *WorkflowExecTracker) MarkExecuted(serviceName string, workflowName commonworkflow.WorkflowName) (bool, error) {
+func (t *WorkflowExecTracker) MarkExecuted(
+	serviceName string,
+	workflowName commonworkflow.WorkflowName,
+) (bool, error) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
-	key := serviceName + ":" + workflowName.String()
-	_, loaded := t.workflowMap[key]
-	if !loaded {
-		t.workflowMap[key] = struct{}{}
-		t.workflowList = append(t.workflowList, key)
-	}
+	loaded := t.workflowTrace.MarkExecuted(serviceName, workflowName)
 
 	// Save workflowMap after modification
 	if err := t.Save(); err != nil {
-		return !loaded, fmt.Errorf("marked executed but failed to save workflow list: %w", err)
+		return loaded, fmt.Errorf("marked executed but failed to save workflow list: %w", err)
 	}
 
-	return !loaded, nil
+	return loaded, nil
 }
 
 func (t *WorkflowExecTracker) Clear(serviceName []string, workflowNames []commonworkflow.WorkflowName) error {
@@ -88,18 +59,7 @@ func (t *WorkflowExecTracker) Clear(serviceName []string, workflowNames []common
 		t.mu.Lock()
 		defer t.mu.Unlock()
 
-		// Specific services
-		for _, serviceName := range serviceName {
-			for _, workflowName := range workflowNames {
-				key := serviceName + ":" + workflowName.String()
-				delete(t.workflowMap, key)
-			}
-		}
-
-		t.workflowList = make([]string, 0)
-		for key := range t.workflowMap {
-			t.workflowList = append(t.workflowList, key)
-		}
+		t.workflowTrace.Clear(serviceName, workflowNames)
 
 		if err := t.Save(); err != nil {
 			return fmt.Errorf("failed to clear workflow(s) and save workflow list: %w", err)

--- a/internal/pkg/impl/host/app/wms/workflow_exec_tracker_test.go
+++ b/internal/pkg/impl/host/app/wms/workflow_exec_tracker_test.go
@@ -1,12 +1,15 @@
 package wms
 
 import (
-	"os"
+	"errors"
 	"testing"
 
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 
 	commonworkflow "github.com/spaulg/solo/internal/pkg/impl/common/domain/wms"
+	"github.com/spaulg/solo/internal/pkg/impl/host/domain"
+	"github.com/spaulg/solo/test/mocks/host/infra/repository"
 )
 
 func TestWorkflowExecTrackerTestSuite(t *testing.T) {
@@ -15,66 +18,73 @@ func TestWorkflowExecTrackerTestSuite(t *testing.T) {
 
 type WorkflowExecTrackerTestSuite struct {
 	suite.Suite
+
+	mockRepository *repository.MockJSONFileRepository[*domain.WorkflowExecTrace]
+	trackingFile   string
 }
 
-func (t *WorkflowExecTrackerTestSuite) TestSaveTracking() {
-	trackingFile := t.T().TempDir() + "/workflow_exec_tracker.json"
-	executionTracker, err := LoadWorkflowExecTracker(trackingFile)
+func (t *WorkflowExecTrackerTestSuite) SetupTest() {
+	t.trackingFile = "workflow_exec_tracker.json"
+	t.mockRepository = &repository.MockJSONFileRepository[*domain.WorkflowExecTrace]{}
+}
+
+func (t *WorkflowExecTrackerTestSuite) TestExecutionTracking() {
+	var workflowList []string
+
+	workflowExecTrace := domain.NewWorkflowExecTrace()
+	t.mockRepository.On("Load", t.trackingFile).Return(workflowExecTrace, nil)
+
+	t.mockRepository.On("Save", t.trackingFile, mock.AnythingOfType("*domain.WorkflowExecTrace")).Run(func(args mock.Arguments) {
+		filePath := args.Get(0).(string)
+		t.Equal(filePath, t.trackingFile)
+
+		trace := args.Get(1).(*domain.WorkflowExecTrace)
+		t.Equal(workflowList, trace.Get())
+	}).Return(nil)
+
+	executionTracker, err := NewWorkflowExecTracker(t.trackingFile, t.mockRepository)
+	t.NoError(err)
+
+	workflowList = []string{"service:first_pre_start_service"}
+	loaded, err := executionTracker.MarkExecuted("service", commonworkflow.FirstPreStartService)
+	t.NoError(err)
+	t.True(loaded)
+
+	workflowList = []string{"service:first_pre_start_service", "service:pre_start_service"}
+	loaded2, err := executionTracker.MarkExecuted("service", commonworkflow.PreStartService)
+	t.NoError(err)
+	t.True(loaded2)
+
+	workflowList = []string{"service:pre_start_service"}
+	err = executionTracker.Clear([]string{"service"}, []commonworkflow.WorkflowName{commonworkflow.FirstPreStartService})
+	t.NoError(err)
+
+	t.mockRepository.AssertExpectations(t.T())
+}
+
+func (t *WorkflowExecTrackerTestSuite) TestSaveReturnsError() {
+	workflowExecTrace := domain.NewWorkflowExecTrace()
+	t.mockRepository.On("Load", t.trackingFile).Return(workflowExecTrace, nil)
+
+	t.mockRepository.On("Save", t.trackingFile, mock.AnythingOfType("*domain.WorkflowExecTrace")).Return(errors.New("mock save error"))
+
+	executionTracker, err := NewWorkflowExecTracker(t.trackingFile, t.mockRepository)
 	t.NoError(err)
 
 	loaded, err := executionTracker.MarkExecuted("service", commonworkflow.FirstPreStartService)
-	t.NoError(err)
-
+	t.ErrorContains(err, "mock save error")
 	t.True(loaded)
-	t.FileExists(trackingFile)
 
-	loaded2, err := executionTracker.MarkExecuted("service", commonworkflow.PreStartService)
-	t.NoError(err)
+	err = executionTracker.Clear([]string{"service"}, []commonworkflow.WorkflowName{commonworkflow.FirstPreStartService})
+	t.ErrorContains(err, "mock save error")
 
-	t.True(loaded2)
-
-	data, err := os.ReadFile(trackingFile)
-	t.NoError(err)
-
-	t.Contains(string(data), `["service:first_pre_start_service","service:pre_start_service"]`)
-
-	loaded3, err := executionTracker.MarkExecuted("service", commonworkflow.PostStartService)
-	t.NoError(err)
-
-	t.True(loaded3)
-
-	data, err = os.ReadFile(trackingFile)
-	t.NoError(err)
-
-	t.Contains(string(data), `["service:first_pre_start_service","service:pre_start_service","service:post_start_service"]`)
-
-	loaded4, err := executionTracker.MarkExecuted("service", commonworkflow.PostStartService)
-	t.NoError(err)
-
-	t.False(loaded4)
-
-	data, err = os.ReadFile(trackingFile)
-	t.NoError(err)
-
-	t.Contains(string(data), `["service:first_pre_start_service","service:pre_start_service","service:post_start_service"]`)
+	t.mockRepository.AssertExpectations(t.T())
 }
 
-func (t *WorkflowExecTrackerTestSuite) TestLoadTracking() {
-	trackingFile := t.T().TempDir() + "/workflow_exec_tracker.json"
+func (t *WorkflowExecTrackerTestSuite) TestLoadReturnsError() {
+	t.mockRepository.On("Load", t.trackingFile).Return(nil, errors.New("mock load error"))
 
-	err := os.WriteFile(trackingFile, []byte(`["service:first_pre_start_service","service:pre_start_service"]`), 0600)
-	t.NoError(err)
-
-	executionTracker, err := LoadWorkflowExecTracker(trackingFile)
-	t.NoError(err)
-
-	loaded3, err := executionTracker.MarkExecuted("service", commonworkflow.PostStartService)
-	t.NoError(err)
-
-	t.True(loaded3)
-
-	data, err := os.ReadFile(trackingFile)
-	t.NoError(err)
-
-	t.Contains(string(data), `["service:first_pre_start_service","service:pre_start_service","service:post_start_service"]`)
+	executionTracker, err := NewWorkflowExecTracker(t.trackingFile, t.mockRepository)
+	t.ErrorContains(err, "mock load error")
+	t.Nil(executionTracker)
 }

--- a/internal/pkg/impl/host/domain/workflow_exec_trace.go
+++ b/internal/pkg/impl/host/domain/workflow_exec_trace.go
@@ -1,0 +1,63 @@
+package domain
+
+import (
+	commonworkflow "github.com/spaulg/solo/internal/pkg/impl/common/domain/wms"
+)
+
+type WorkflowExecTrace struct {
+	workflowMap  map[string]struct{}
+	WorkflowList []string `json:"workflow_list"`
+}
+
+func NewWorkflowExecTrace() *WorkflowExecTrace {
+	return &WorkflowExecTrace{
+		workflowMap:  make(map[string]struct{}),
+		WorkflowList: make([]string, 0),
+	}
+}
+
+func (t *WorkflowExecTrace) ensureInitialized() {
+	if t.workflowMap == nil {
+		t.workflowMap = make(map[string]struct{}, len(t.WorkflowList))
+		for _, key := range t.WorkflowList {
+			t.workflowMap[key] = struct{}{}
+		}
+	}
+
+	if t.WorkflowList == nil {
+		t.WorkflowList = make([]string, 0)
+	}
+}
+
+func (t *WorkflowExecTrace) MarkExecuted(serviceName string, workflowName commonworkflow.WorkflowName) bool {
+	t.ensureInitialized()
+
+	key := serviceName + ":" + workflowName.String()
+	_, loaded := t.workflowMap[key]
+	if !loaded {
+		t.workflowMap[key] = struct{}{}
+		t.WorkflowList = append(t.WorkflowList, key)
+	}
+
+	return !loaded
+}
+
+func (t *WorkflowExecTrace) Clear(serviceName []string, workflowNames []commonworkflow.WorkflowName) {
+	t.ensureInitialized()
+
+	for _, serviceName := range serviceName {
+		for _, workflowName := range workflowNames {
+			key := serviceName + ":" + workflowName.String()
+			delete(t.workflowMap, key)
+		}
+	}
+
+	t.WorkflowList = make([]string, 0)
+	for key := range t.workflowMap {
+		t.WorkflowList = append(t.WorkflowList, key)
+	}
+}
+
+func (t *WorkflowExecTrace) Get() []string {
+	return t.WorkflowList
+}

--- a/internal/pkg/impl/host/domain/workflow_exec_trace_repository.go
+++ b/internal/pkg/impl/host/domain/workflow_exec_trace_repository.go
@@ -1,0 +1,5 @@
+package domain
+
+type WorkflowExecTraceRepository interface {
+	EntityRepository[*WorkflowExecTrace]
+}

--- a/internal/pkg/impl/host/domain/workflow_exec_trace_test.go
+++ b/internal/pkg/impl/host/domain/workflow_exec_trace_test.go
@@ -1,0 +1,39 @@
+package domain
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	commonworkflow "github.com/spaulg/solo/internal/pkg/impl/common/domain/wms"
+)
+
+func TestWorkflowExecTraceTestSuite(t *testing.T) {
+	suite.Run(t, new(WorkflowExecTraceTestSuite))
+}
+
+type WorkflowExecTraceTestSuite struct {
+	suite.Suite
+}
+
+func (t *WorkflowExecTraceTestSuite) TestNewWorkflowExecTrace() {
+	workflowExecTrace := NewWorkflowExecTrace()
+	t.NotNil(workflowExecTrace)
+
+	var loaded bool
+
+	loaded = workflowExecTrace.MarkExecuted("service", commonworkflow.FirstPreStartService)
+	t.Equal([]string{"service:first_pre_start_service"}, workflowExecTrace.Get())
+	t.True(loaded)
+
+	loaded = workflowExecTrace.MarkExecuted("service", commonworkflow.PreStartService)
+	t.Equal([]string{"service:first_pre_start_service", "service:pre_start_service"}, workflowExecTrace.Get())
+	t.True(loaded)
+
+	loaded = workflowExecTrace.MarkExecuted("service", commonworkflow.FirstPreStartService)
+	t.Equal([]string{"service:first_pre_start_service", "service:pre_start_service"}, workflowExecTrace.Get())
+	t.False(loaded)
+
+	workflowExecTrace.Clear([]string{"service"}, []commonworkflow.WorkflowName{commonworkflow.FirstPreStartService})
+	t.Equal([]string{"service:pre_start_service"}, workflowExecTrace.Get())
+}

--- a/internal/pkg/impl/host/infra/grpc/mutual_tls_server_factory.go
+++ b/internal/pkg/impl/host/infra/grpc/mutual_tls_server_factory.go
@@ -14,7 +14,6 @@ import (
 	"github.com/spaulg/solo/internal/pkg/impl/host/app/context"
 	"github.com/spaulg/solo/internal/pkg/impl/host/infra/certificate"
 	"github.com/spaulg/solo/internal/pkg/impl/host/infra/grpc/service_definitions"
-	"github.com/spaulg/solo/internal/pkg/types/host/app/wms"
 	project_types "github.com/spaulg/solo/internal/pkg/types/host/domain"
 )
 
@@ -38,7 +37,7 @@ func NewMutualTLSServerFactory(
 
 func (t *MutualTLSServerFactory) Build(
 	orchestrator ContainerResolver,
-	workflowExecutionTracker wms.WorkflowExecTracker,
+	workflowExecutionTracker service_definitions.WorkflowExecTracker,
 	project project_types.Project,
 	port int,
 ) (Server, error) {

--- a/internal/pkg/impl/host/infra/grpc/server_factory.go
+++ b/internal/pkg/impl/host/infra/grpc/server_factory.go
@@ -1,14 +1,14 @@
 package grpc
 
 import (
-	wms_types "github.com/spaulg/solo/internal/pkg/types/host/app/wms"
+	"github.com/spaulg/solo/internal/pkg/impl/host/infra/grpc/service_definitions"
 	project_types "github.com/spaulg/solo/internal/pkg/types/host/domain"
 )
 
 type ServerFactory interface {
 	Build(
 		orchestrator ContainerResolver,
-		workflowExecutionTracker wms_types.WorkflowExecTracker,
+		workflowExecutionTracker service_definitions.WorkflowExecTracker,
 		project project_types.Project,
 		port int,
 	) (Server, error)

--- a/internal/pkg/impl/host/infra/grpc/service_definitions/workflow_exec_tracker.go
+++ b/internal/pkg/impl/host/infra/grpc/service_definitions/workflow_exec_tracker.go
@@ -1,4 +1,4 @@
-package wms
+package service_definitions
 
 import (
 	commonworkflow "github.com/spaulg/solo/internal/pkg/impl/common/domain/wms"

--- a/internal/pkg/impl/host/infra/grpc/service_definitions/workflow_service.go
+++ b/internal/pkg/impl/host/infra/grpc/service_definitions/workflow_service.go
@@ -9,21 +9,20 @@ import (
 	commonworkflow "github.com/spaulg/solo/internal/pkg/impl/common/domain/wms"
 	"github.com/spaulg/solo/internal/pkg/impl/common/infra/grpc/services"
 	solo_context "github.com/spaulg/solo/internal/pkg/impl/host/app/context"
-	wms_types "github.com/spaulg/solo/internal/pkg/types/host/app/wms"
 )
 
 type WorkflowServerImpl struct {
 	soloCtx *solo_context.CliContext
 	services.UnimplementedWorkflowServer
 	orchestrator        ContainerImageWorkingDirectoryResolver
-	workflowExecTracker wms_types.WorkflowExecTracker
+	workflowExecTracker WorkflowExecTracker
 	workflowRunner      WorkflowRunner
 }
 
 func NewWorkflowService(
 	soloCtx *solo_context.CliContext,
 	orchestrator ContainerImageWorkingDirectoryResolver,
-	workflowExecTracker wms_types.WorkflowExecTracker,
+	workflowExecTracker WorkflowExecTracker,
 	workflowRunner WorkflowRunner,
 ) *WorkflowServerImpl {
 	return &WorkflowServerImpl{

--- a/internal/pkg/impl/host/infra/grpc/service_definitions/workflow_session.go
+++ b/internal/pkg/impl/host/infra/grpc/service_definitions/workflow_session.go
@@ -11,14 +11,13 @@ import (
 	solo_context "github.com/spaulg/solo/internal/pkg/impl/host/app/context"
 	"github.com/spaulg/solo/internal/pkg/impl/host/infra/grpc/interceptors"
 	wms_shared "github.com/spaulg/solo/internal/pkg/impl/host/shared/wms"
-	"github.com/spaulg/solo/internal/pkg/types/host/app/wms"
 )
 
 type WorkflowSession struct {
 	soloCtx             *solo_context.CliContext
 	workflowName        commonworkflow.WorkflowName
 	server              grpc.BidiStreamingServer[services.WorkflowStreamRequest, services.WorkflowStreamResponse]
-	workflowExecTracker wms.WorkflowExecTracker
+	workflowExecTracker WorkflowExecTracker
 	orchestrator        ContainerImageWorkingDirectoryResolver
 
 	serviceName       string
@@ -30,7 +29,7 @@ func NewWorkflowSession(
 	soloCtx *solo_context.CliContext,
 	workflowName commonworkflow.WorkflowName,
 	server grpc.BidiStreamingServer[services.WorkflowStreamRequest, services.WorkflowStreamResponse],
-	workflowExecTracker wms.WorkflowExecTracker,
+	workflowExecTracker WorkflowExecTracker,
 	orchestrator ContainerImageWorkingDirectoryResolver,
 ) (*WorkflowSession, error) {
 	ctx := server.Context()

--- a/test/mocks/host/infra/grpc/server_factory.go
+++ b/test/mocks/host/infra/grpc/server_factory.go
@@ -4,7 +4,7 @@ import (
 	"github.com/stretchr/testify/mock"
 
 	"github.com/spaulg/solo/internal/pkg/impl/host/infra/grpc"
-	wms_types "github.com/spaulg/solo/internal/pkg/types/host/app/wms"
+	wms_types "github.com/spaulg/solo/internal/pkg/impl/host/infra/grpc/service_definitions"
 	project_types "github.com/spaulg/solo/internal/pkg/types/host/domain"
 )
 

--- a/test/mocks/host/infra/repository/json_file_repository.go
+++ b/test/mocks/host/infra/repository/json_file_repository.go
@@ -1,0 +1,27 @@
+package repository
+
+import (
+	"github.com/stretchr/testify/mock"
+)
+
+type MockJSONFileRepository[T any] struct {
+	mock.Mock
+}
+
+func (m *MockJSONFileRepository[T]) Save(filePath string, entity T) error {
+	args := m.Called(filePath, entity)
+	return args.Error(0)
+}
+
+func (m *MockJSONFileRepository[T]) Load(filePath string) (T, error) {
+	var s T
+	var ok bool
+
+	args := m.Called(filePath)
+
+	if s, ok = args.Get(0).(T); ok {
+		return s, args.Error(1)
+	}
+
+	return s, args.Error(1)
+}


### PR DESCRIPTION
Split the workflow execution tracker to a domain object and repository